### PR TITLE
Experimental block-based keystream generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Instead of using a static key, VernamVeil allows the key to be represented by a 
 - `i`: the index of the bytes in the message; a scalar integer or an uint64 NumPy array with a continuous enumeration for vectorised operations.
 - `seed`: a byte string that provides context and state; should be kept secret.
 - `bound`: an optional integer used to modulo the function output into the desired range (usually `2**64` because we sample 8 bytes at a time).
-- **Output**: an integer or an uint64 NumPy array representing the key stream values.
+- **Output**: an integer or bytes or an uint64/uint8 NumPy array representing the key stream values.
 
 _Note: `numpy` is an optional but highly recommended dependency, used to accelerate vectorised operations when available._
 

--- a/tests/test_deniability_utils.py
+++ b/tests/test_deniability_utils.py
@@ -15,9 +15,9 @@ class TestDeniabilityUtils(unittest.TestCase):
         self,
         chunk_size,
         delimiter_size,
-        padding_range=(5, 15),
-        decoy_ratio=0.2,
-        vectorise=False,
+        padding_range,
+        decoy_ratio,
+        vectorise,
     ):
         """Utility to run a basic deniability test with configurable parameters."""
         real_fx = generate_default_fx(vectorise=vectorise)
@@ -185,7 +185,7 @@ def make_test_func(chunk_size, delimiter_size):
                     decoy_out, decoy_message = self._run_deniability_test(
                         chunk_size=chunk_size,
                         delimiter_size=delimiter_size,
-                        padding_range=(5, 15),
+                        padding_range=(5, 150),
                         decoy_ratio=0.3,
                         vectorise=vectorise,
                     )

--- a/tests/test_deniability_utils.py
+++ b/tests/test_deniability_utils.py
@@ -13,8 +13,8 @@ class TestDeniabilityUtils(unittest.TestCase):
 
     def _run_deniability_test(
         self,
-        chunk_size=31,
-        delimiter_size=9,
+        chunk_size,
+        delimiter_size,
         padding_range=(5, 15),
         decoy_ratio=0.2,
         vectorise=False,
@@ -168,8 +168,8 @@ class TestDeniabilityUtils(unittest.TestCase):
 
 
 # Generate all combinations
-chunk_sizes = [31, 32, 33]
-delimiter_sizes = [7, 8, 9]
+chunk_sizes = [127, 128, 129]
+delimiter_sizes = [7, 8, 9, 63, 64, 65]
 combos = list(itertools.product(chunk_sizes, delimiter_sizes))
 
 

--- a/tests/test_deniability_utils.py
+++ b/tests/test_deniability_utils.py
@@ -61,8 +61,8 @@ class TestDeniabilityUtils(unittest.TestCase):
 
     def test_plausible_fx_source_code_roundtrip(self):
         """Test that _PlausibleFX source code can be saved and loaded, preserving integers."""
-        test_ints = [42, 99, 123456, 7, 0]
-        fx = _PlausibleFX(test_ints)
+        test_keystream = [b"42", b"99", b"123456", b"7", b"0"]
+        fx = _PlausibleFX(test_keystream)
         source_code = fx._source_code
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -70,8 +70,8 @@ class TestDeniabilityUtils(unittest.TestCase):
             with open(path, "w") as f:
                 f.write(source_code)
             loaded_fx = load_fx_from_file(str(path))
-            self.assertTrue(hasattr(loaded_fx, "_uint64s"))
-            self.assertEqual(list(loaded_fx._uint64s), test_ints)
+            self.assertTrue(hasattr(loaded_fx, "_keystream"))
+            self.assertEqual(list(loaded_fx._keystream), test_keystream)
 
     def test_end_to_end_deniability_disk_io(self):
         """End-to-end test: store/load all artifacts and verify deniability."""
@@ -80,8 +80,8 @@ class TestDeniabilityUtils(unittest.TestCase):
         secret_message = b"Sensitive data: the launch code is 12345!"
         cypher = VernamVeil(
             real_fx,
-            chunk_size=32,
-            delimiter_size=8,
+            chunk_size=33,
+            delimiter_size=9,
             padding_range=(5, 15),
             decoy_ratio=0.2,
             siv_seed_initialisation=True,
@@ -140,8 +140,8 @@ class TestDeniabilityUtils(unittest.TestCase):
             # Decrypt with real fx/seed
             real_cypher = VernamVeil(
                 loaded_real_fx,
-                chunk_size=32,
-                delimiter_size=8,
+                chunk_size=33,
+                delimiter_size=9,
                 padding_range=(5, 15),
                 decoy_ratio=0.2,
                 siv_seed_initialisation=True,
@@ -153,8 +153,8 @@ class TestDeniabilityUtils(unittest.TestCase):
             # Decrypt with plausible fx/fake seed
             fake_cypher = VernamVeil(
                 loaded_plausible_fx,
-                chunk_size=32,
-                delimiter_size=8,
+                chunk_size=33,
+                delimiter_size=9,
                 padding_range=(5, 15),
                 decoy_ratio=0.2,
                 siv_seed_initialisation=False,

--- a/vernamveil/_deniability_utils.py
+++ b/vernamveil/_deniability_utils.py
@@ -10,7 +10,7 @@ import copy
 import math
 from typing import Any
 
-from vernamveil._vernamveil import VernamVeil, _IntOrArray
+from vernamveil._vernamveil import VernamVeil, _IntOrArray, _IntOrBytes
 
 np: Any
 try:
@@ -112,7 +112,7 @@ fx = _PlausibleFX({keystream})
 
 """
 
-    def __call__(self, i: _IntOrArray, _: bytes, __: int | None = None) -> _IntOrArray:
+    def __call__(self, i: _IntOrArray, _: bytes, __: int | None = None) -> _IntOrBytes:
         """Generates the next value in the fake keystream.
 
         Args:
@@ -121,7 +121,7 @@ fx = _PlausibleFX({keystream})
             __ (int, optional): Unused parameter for compatibility.
 
         Returns:
-            _IntOrArray: The next value in the fake keystream.
+            _IntOrBytes: The next value in the fake keystream.
         """
         use_numpy = np is not None and isinstance(i, np.ndarray)
 

--- a/vernamveil/_deniability_utils.py
+++ b/vernamveil/_deniability_utils.py
@@ -195,7 +195,9 @@ def forge_plausible_fx(
     delimiter_bytes = delimiter.tobytes().ljust(delimiter_len, b"\x00")
 
     # 4. Prepend the delimiter bytes to the keystream_values
-    keystream_values = [delimiter_bytes]
+    keystream_values = [
+        delimiter_bytes[i : i + block_size] for i in range(0, delimiter_len, block_size)
+    ]
 
     # 5. Recover the keystream: keystream = cyphertext ^ obfuscated
     # We need to recover the chunk ranges for the obfuscated message to handle the case where

--- a/vernamveil/_deniability_utils.py
+++ b/vernamveil/_deniability_utils.py
@@ -8,7 +8,7 @@ The utility reuses as many private methods of VernamVeil as possible to ensure c
 
 import copy
 import math
-from typing import Any, Literal
+from typing import Any
 
 from vernamveil._vernamveil import VernamVeil, _IntOrArray
 
@@ -96,29 +96,29 @@ def _estimate_obfuscated_length(cypher: VernamVeil, message_len: int, pad_val: i
 class _PlausibleFX:
     """A callable class that generates fake keystream values for plausible deniability."""
 
-    def __init__(self, uint64s: list[int]):
+    def __init__(self, keystream: list[bytes]):
         """Initializes the PlausibleFX instance.
 
         Args:
-            uint64s (list[int]): A list of 64-bit unsigned integers representing the fake keystream.
+            keystream (list[bytes]): A list of bytes representing the fake keystream.
         """
-        self._uint64s = uint64s
+        self._keystream = keystream
         self._pos = 0
-        self._len = len(uint64s)
+        self._len = len(keystream)
         self._source_code = f"""
 from vernamveil._deniability_utils import _PlausibleFX
 
-fx = _PlausibleFX({uint64s})
+fx = _PlausibleFX({keystream})
 
 """
 
-    def __call__(self, i: _IntOrArray, _: bytes, bound: int | None = None) -> _IntOrArray:
+    def __call__(self, i: _IntOrArray, _: bytes, __: int | None = None) -> _IntOrArray:
         """Generates the next value in the fake keystream.
 
         Args:
             i (_IntOrArray): the index of the bytes in the message.
             _ (bytes): Unused parameter for compatibility.
-            bound (int, optional): An optional bound to limit the generated value.
+            __ (int, optional): Unused parameter for compatibility.
 
         Returns:
             _IntOrArray: The next value in the fake keystream.
@@ -127,18 +127,15 @@ fx = _PlausibleFX({uint64s})
 
         n = len(i) if use_numpy else 1
         vals = []
-        for __ in range(n):
+        for ___ in range(n):
             if self._pos >= self._len:
                 self._pos = 0
-            val = self._uint64s[self._pos]
-            if bound is not None:
-                val %= bound
-            vals.append(val)
+            vals.append(self._keystream[self._pos])
             self._pos += 1
 
         if not use_numpy:
             return vals[0]
-        return np.array(vals, dtype=np.uint64)
+        return np.fromiter((b for chunk in vals for b in chunk), dtype=np.uint8)
 
 
 def forge_plausible_fx(
@@ -172,7 +169,6 @@ def forge_plausible_fx(
     cypher = copy.deepcopy(cypher)
     cypher._siv_seed_initialisation = False
     cypher._auth_encrypt = False
-    endianness: Literal["little", "big"] = "little" if cypher._vectorise else "big"
 
     # 2. Estimate the plausible boundaries for the cyphertext length
     cyphertext_len = len(cyphertext)
@@ -193,26 +189,29 @@ def forge_plausible_fx(
         cypher, decoy_message, cyphertext_len, max_attempts=max_obfuscate_attempts
     )
 
-    # 3. Generate the delimiter bytes and make sure they are a multiple of 8
-    delimiter_len = math.ceil(len(delimiter) / 8) * 8
-    delimiter = memoryview(delimiter.tobytes().ljust(delimiter_len, b"\x00"))
+    # 3. Generate the delimiter bytes and make sure they are a multiple of block_size
+    block_size = cypher._block_size
+    delimiter_len = math.ceil(len(delimiter) / block_size) * block_size
+    delimiter_bytes = delimiter.tobytes().ljust(delimiter_len, b"\x00")
 
-    # 4. Prepend the delimiter bytes to the uint64s
-    uint64s = [int.from_bytes(delimiter[i : i + 8], endianness) for i in range(0, delimiter_len, 8)]
+    # 4. Prepend the delimiter bytes to the keystream_values
+    keystream_values = [delimiter_bytes]
 
     # 5. Recover the keystream: keystream = cyphertext ^ obfuscated
     # We need to recover the chunk ranges for the obfuscated message to handle the case where
-    # the chunk_size is not a multiple of 8. This can lead to the fx sampling the wrong bytes.
+    # the chunk_size is not a multiple of block_size. This can lead to the fx sampling the wrong bytes.
     for start, end in cypher._generate_chunk_ranges(cyphertext_len):
-        for block_start in range(start, end, 8):
-            # Pad to 8 bytes if needed
-            ct_block = cyphertext[block_start : block_start + 8].ljust(8, b"\x00")
-            obf_block = obfuscated[block_start : block_start + 8].ljust(8, b"\x00")
+        for block_start in range(start, end, block_size):
+            # Pad to block_size bytes if needed
+            ct_block = cyphertext[block_start : block_start + block_size].ljust(block_size, b"\x00")
+            obf_block = obfuscated[block_start : block_start + block_size].ljust(
+                block_size, b"\x00"
+            )
 
-            ks_uint64 = int.from_bytes((a ^ b for a, b in zip(ct_block, obf_block)), endianness)
-            uint64s.append(ks_uint64)
+            ks = bytes(a ^ b for a, b in zip(ct_block, obf_block))
+            keystream_values.append(ks)
 
     # 6. Generate the fx function
-    plausible_fx = _PlausibleFX(uint64s)
+    plausible_fx = _PlausibleFX(keystream_values)
 
     return plausible_fx, fake_seed

--- a/vernamveil/_fx_utils.py
+++ b/vernamveil/_fx_utils.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Callable, Literal, cast
 
 from vernamveil._hash_utils import _UINT64_BOUND, fold_bytes_to_uint64, hash_numpy
-from vernamveil._vernamveil import _IntOrArray
+from vernamveil._vernamveil import _IntOrArray, _IntOrBytes
 
 np: Any
 try:
@@ -33,7 +33,7 @@ __all__ = [
 def generate_hmac_fx(
     hash_name: Literal["blake2b", "sha256"] = "blake2b",
     vectorise: bool = False,
-) -> Callable[[_IntOrArray, bytes, int | None], _IntOrArray]:
+) -> Callable[[_IntOrArray, bytes, int | None], _IntOrBytes]:
     """Generate a standard HMAC-based pseudorandom function (PRF) using Blake2b or SHA256.
 
     Args:
@@ -41,7 +41,7 @@ def generate_hmac_fx(
         vectorise (bool): If True, uses numpy arrays as input for vectorised operations.
 
     Returns:
-        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray]: A function that returns pseudo-random
+        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray | bytes]: A function that returns pseudo-random
             integers from HMAC-based function.
 
     Raises:
@@ -114,12 +114,12 @@ def fx(i: int, seed: bytes, bound: int | None) -> int:
     fx = local_vars["fx"]
     fx._source_code = function_code
 
-    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrArray], fx)
+    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrBytes], fx)
 
 
 def generate_polynomial_fx(
     degree: int = 10, max_weight: int = 10**5, vectorise: bool = False
-) -> Callable[[_IntOrArray, bytes, int | None], _IntOrArray]:
+) -> Callable[[_IntOrArray, bytes, int | None], _IntOrBytes]:
     """Generate a random polynomial-based secret function to act as a deterministic key stream generator.
 
     The transformed input index is passed to a cryptographic hash function (HMAC) and bounded to the requested range.
@@ -132,7 +132,7 @@ def generate_polynomial_fx(
         vectorise (bool): If True, uses numpy arrays as input for vectorised operations.
 
     Returns:
-        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray]: A function that returns pseudo-random
+        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray | bytes]: A function that returns pseudo-random
             integers from polynomial evaluation.
 
     Raises:
@@ -236,32 +236,32 @@ def fx(i: int, seed: bytes, bound: int | None) -> int:
     # Attach the code string directly to the function object for later reference
     fx._source_code = function_code
 
-    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrArray], fx)
+    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrBytes], fx)
 
 
 # Default function for key stream generation
 generate_default_fx = generate_polynomial_fx
 
 
-def load_fx_from_file(path: str | Path) -> Callable[[_IntOrArray, bytes, int | None], _IntOrArray]:
+def load_fx_from_file(path: str | Path) -> Callable[[_IntOrArray, bytes, int | None], _IntOrBytes]:
     """Load the fx function from a Python file.
 
     Args:
         path (str | Path): Path to the Python file containing fx.
 
     Returns:
-        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray]: The loaded fx function.
+        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray | bytes]: The loaded fx function.
     """
     global_vars: dict[str, Any] = {}
     path_obj = Path(path)
     code = path_obj.read_text()
     exec(code, global_vars)
     fx = global_vars["fx"]
-    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrArray], fx)
+    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrBytes], fx)
 
 
 def check_fx_sanity(
-    fx: Callable[[_IntOrArray, bytes, int | None], _IntOrArray],
+    fx: Callable[[_IntOrArray, bytes, int | None], _IntOrBytes],
     seed: bytes,
     bound: int = 256,
     num_samples: int = 1000,

--- a/vernamveil/_fx_utils.py
+++ b/vernamveil/_fx_utils.py
@@ -67,11 +67,13 @@ def fx(i: np.ndarray, seed: bytes, bound: int | None) -> np.ndarray:
 
     # Cryptographic HMAC using {hash_name}
     hash_result = hash_numpy(i, seed, "{hash_name}")  # uses C module if available, else NumPy fallback
-    result = fold_bytes_to_uint64(hash_result)
 
-    # Modulo the result with the bound to ensure it's always within the requested range
+    # Convert to uint64 and modulo the result with the bound to ensure it's always within the requested range
     if bound is not None:
+        result = fold_bytes_to_uint64(hash_result)
         np.remainder(result, bound, out=result)
+    else:
+        result = hash_result
 
     return result
 """
@@ -176,11 +178,13 @@ def fx(i: np.ndarray, seed: bytes, bound: int | None) -> np.ndarray:
 
     # Cryptographic HMAC using Blake2b
     hash_result = hash_numpy(result, seed, "blake2b")  # uses C module if available, else NumPy fallback
-    result = fold_bytes_to_uint64(hash_result)
 
-    # Modulo the result with the bound to ensure it's always within the requested range
+    # Convert to uint64 and modulo the result with the bound to ensure it's always within the requested range
     if bound is not None:
+        result = fold_bytes_to_uint64(hash_result)
         np.remainder(result, bound, out=result)
+    else:
+        result = hash_result
 
     return result
 """

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -16,16 +16,19 @@ from vernamveil._hash_utils import _UINT64_BOUND, fold_bytes_to_uint64, hash_num
 
 np: Any
 _IntOrArray: Any
+_IntOrBytes: Any
 try:
     import numpy
     from numpy.typing import NDArray
 
     np = numpy
     _IntOrArray = int | NDArray
+    _IntOrBytes = int | NDArray | bytes
     _HAS_NUMPY = True
 except ImportError:
     np = None
     _IntOrArray = int
+    _IntOrBytes = int | bytes
     _HAS_NUMPY = False
 
 
@@ -43,7 +46,7 @@ class VernamVeil(_Cypher):
 
     def __init__(
         self,
-        fx: Callable[[_IntOrArray, bytes, int | None], _IntOrArray],
+        fx: Callable[[_IntOrArray, bytes, int | None], _IntOrBytes],
         chunk_size: int = 32,
         delimiter_size: int = 8,
         padding_range: tuple[int, int] = (5, 15),
@@ -56,7 +59,7 @@ class VernamVeil(_Cypher):
 
         Args:
             fx (Callable): Key stream generator accepting (int | np.ndarray, bytes, int | None) and returning an
-                int or np.ndarray. This function is critical for the encryption process and should be carefully
+                int or np.ndarray or bytes. This function is critical for the encryption process and should be carefully
                 designed to ensure cryptographic security.
             chunk_size (int): Size of message chunks. Defaults to 32.
             delimiter_size (int): The delimiter size in bytes used for separating chunks; must be


### PR DESCRIPTION
This is 8x faster (3sec for 50mb, 20sec for 1GB).

...But complicates a lot the API:
- Unless we move the HMAC outside of the fx, we can't guarantee we'll have sufficient `_block_size`. The current approach only works if the user uses Blake2b within their fx, which is not guaranteed.
- The methods now can return both integers and bytes. What they return depends on providing a bound, which complicates the fx.
- The sanity check methods won't work properly if we return bytes.
- The deniability utils become even more hacky.