### PR TITLE
Block-based keystream generation

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set benchmark sizes
         id: benchvars
         run: |
-          echo "SIZES=5 25 125" >> $GITHUB_ENV
+          echo "SIZES=5 25 100" >> $GITHUB_ENV
 
       - name: Install system dependencies and build C modules
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set benchmark sizes
         id: benchvars
         run: |
-          echo "SIZES=1 5 25" >> $GITHUB_ENV
+          echo "SIZES=5 25 125" >> $GITHUB_ENV
 
       - name: Install system dependencies and build C modules
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set benchmark sizes
         id: benchvars
         run: |
-          echo "SIZES=5 25 100" >> $GITHUB_ENV
+          echo "SIZES=5 25 75" >> $GITHUB_ENV
 
       - name: Install system dependencies and build C modules
         run: |

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ decrypted, _ = cypher.decode(encrypted, initial_seed)
 
 **VernamVeil** is an experimental cypher inspired by the **One-Time Pad (OTP)** developed in Python. The name honours **Gilbert Vernam**, who is credited with the theoretical foundation of the OTP.
 
-Instead of using a static key, VernamVeil allows the key to be represented by a function `fx(i: int | np.ndarray, seed: bytes, bound: int | None) -> int | np.ndarray`:
+Instead of using a static key, VernamVeil allows the key to be represented by a function `fx(i: int | np.ndarray[np.uint64], seed: bytes, bound: int | None) -> bytes | np.ndarray[np.uint8]`:
 - `i`: the index of the bytes in the message; a scalar integer or an uint64 NumPy array with a continuous enumeration for vectorised operations.
 - `seed`: a byte string that provides context and state; should be kept secret.
 - `bound`: an optional integer used to modulo the function output into the desired range (usually `2**64` because we sample 8 bytes at a time).
-- **Output**: an integer or bytes or an uint64/uint8 NumPy array representing the key stream values.
+- **Output**: bytes or uint8 NumPy array representing the key stream values.
 
 _Note: `numpy` is an optional but highly recommended dependency, used to accelerate vectorised operations when available._
 

--- a/README.md
+++ b/README.md
@@ -194,8 +194,7 @@ def fx(i: int, seed: bytes) -> int:
         current_pow = (current_pow * i) % interim_modulus  # Avoid large power growth
     
     # Cryptographic HMAC using Blake2b
-    hash_result = hmac.new(seed, result.to_bytes(8, "big"), digestmod="blake2b").digest()
-    result = int.from_bytes(hash_result, "big")
+    result = hmac.new(seed, result.to_bytes(8, "big"), digestmod="blake2b").digest()
 
     return result
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ def fx(i: int, seed: bytes) -> int:
     # Simple but cryptographically unsafe fx; see below for a more complex example
     b = seed[i % len(seed)]
     result = ((i ** 2 + i * b + b ** 2) * (i + 7))
-    return result
+    return result.to_bytes((result.bit_length() + 7) // 8, "big")
 
 
 # Step 2: Generate a random initial seed for encryption

--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ pip install .
 
 Minimal Example:
 ```python
-from vernamveil import VernamVeil
+from vernamveil import FX, VernamVeil
 
 
 # Step 1: Define a custom key stream function; remember to store this securely
-def fx(i: int, seed: bytes) -> int:
+def keystream_fn(i: int, seed: bytes) -> int:
     # Simple but cryptographically unsafe fx; see below for a more complex example
     b = seed[i % len(seed)]
     result = ((i ** 2 + i * b + b ** 2) * (i + 7))
-    return result.to_bytes((result.bit_length() + 7) // 8, "big")
+    result &= 0xFFFFFFFFFFFFFFFF
+    return result.to_bytes(8, "big")
+
+fx = FX(keystream_fn, 8, vectorise=False)
 
 
 # Step 2: Generate a random initial seed for encryption
@@ -94,7 +97,7 @@ from vernamveil import VernamVeil, generate_default_fx
 
 
 # Step 1: Generate a random custom fx using the helper
-fx = generate_default_fx()  # remember to store fx._source_code securely
+fx = generate_default_fx()  # remember to store fx.source_code securely
 
 # Step 2: Generate a random initial seed for encryption
 initial_seed = VernamVeil.get_initial_seed()  # remember to store this securely
@@ -130,7 +133,7 @@ from vernamveil import VernamVeil, generate_default_fx
 
 
 # Step 1: Generate a random custom fx using the helper
-fx = generate_default_fx()  # remember to store fx._source_code securely
+fx = generate_default_fx()  # remember to store fx.source_code securely
 
 # Step 2: Generate a random initial seed for encryption
 initial_seed = VernamVeil.get_initial_seed()  # remember to store this securely
@@ -176,71 +179,74 @@ Below we provide some example `fx` methods to illustrate these principles in pra
 
 ```python
 import hmac
+from vernamveil import FX
 
 
-def fx(i: int, seed: bytes) -> int:
+def keystream_fn(i: int, seed: bytes) -> int:
     # Implements a customisable fx function based on a 10-degree polynomial transformation of the index,
-    # followed by a cryptographically secure HMAC-Blake2b output. 
+    # followed by a cryptographically secure HMAC-Blake2b output.
     # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the HMAC.
     # The polynomial transformation adds uniqueness to each fx instance but does not contribute additional entropy.
     weights = [24242, 68652, 77629, 55585, 32284, 78741, 70249, 39611, 54080, 73198, 12426]
-    interim_modulus = 18446744073709551616
-    
+
     # Transform index i using a polynomial function to introduce uniqueness on fx
     current_pow = 1
     result = 0
     for weight in weights:
-        result = (result + weight * current_pow) % interim_modulus
-        current_pow = (current_pow * i) % interim_modulus  # Avoid large power growth
-    
-    # Cryptographic HMAC using Blake2b
-    result = hmac.new(seed, result.to_bytes(8, "big"), digestmod="blake2b").digest()
+        result = (result + weight * current_pow) & 0xFFFFFFFFFFFFFFFF
+        current_pow = (current_pow * i) & 0xFFFFFFFFFFFFFFFF
 
-    return result
+    # Cryptographic HMAC using Blake2b
+    return hmac.new(seed, result.to_bytes(8, "big"), digestmod="blake2b").digest()
+
+
+fx = FX(keystream_fn, block_size=64, vectorise=False)
 ```
 
 ### 🏎️ A fast version of the above `fx` that uses NumPy vectorisation and the `nphash` C module
 
 ```python
-from vernamveil import hash_numpy
+from vernamveil import FX, hash_numpy
 import numpy as np
 
 
-def fx(i: np.ndarray, seed: bytes) -> np.ndarray:
+def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
     # Implements a customisable fx function based on a 10-degree polynomial transformation of the index,
-    # followed by a cryptographically secure HMAC-Blake2b output. 
+    # followed by a cryptographically secure HMAC-Blake2b output.
     # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the HMAC.
     # The polynomial transformation adds uniqueness to each fx instance but does not contribute additional entropy.
     weights = np.array([24242, 68652, 77629, 55585, 32284, 78741, 70249, 39611, 54080, 73198, 12426], dtype=np.uint64)
-    
+
     # Transform index i using a polynomial function to introduce uniqueness on fx
     # Compute all powers: shape (i.size, degree)
     powers = np.power.outer(i, np.arange(11, dtype=np.uint64))
+
     # Weighted sum (polynomial evaluation)
     result = np.dot(powers, weights)
 
     # Cryptographic HMAC using Blake2b
-    result = hash_numpy(result, seed, "blake2b")  # uses C module if available, else NumPy fallback
-    
-    return result
+    return hash_numpy(result, seed, "blake2b")  # uses C module if available, else NumPy fallback
+
+
+fx = FX(keystream_fn, block_size=64, vectorise=True)
 ```
 
 ### 🛡️ A cryptographically strong HMAC-SHA256 `fx` (vectorised & C-accelerated)
 
 ```python
-from vernamveil import hash_numpy
 import numpy as np
+from vernamveil import FX, hash_numpy
 
 
-def fx(i: np.ndarray, seed: bytes) -> np.ndarray:
-    # Implements a standard HMAC-based pseudorandom function (PRF) using sha256.
+def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
+    # Implements a standard HMAC-based pseudorandom function (PRF) using blake2b.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
     # Security relies entirely on the secrecy of the seed and the cryptographic strength of HMAC.
+    # Cryptographic HMAC using blake2b
+    return hash_numpy(i, seed, "blake2b")  # uses C module if available, else NumPy fallback
 
-    # Cryptographic HMAC using sha256
-    result = hash_numpy(i, seed, "sha256")  # uses C module if available, else NumPy fallback
 
-    return result
+fx = FX(keystream_fn, block_size=64, vectorise=True)
 ```
 
 ---
@@ -261,12 +267,11 @@ Example:
 ```python
 from vernamveil import generate_default_fx, check_fx_sanity
 
-
 # Generate a vectorised fx function
 fx = generate_default_fx(vectorise=True)
 
 # Show the generated function's source code
-print("Generated fx source code:\n", fx._source_code)
+print("Generated fx source code:\n", fx.source_code)
 
 # Check if the generated fx passes basic sanity checks
 seed = b"mysecretseed"

--- a/README.md
+++ b/README.md
@@ -25,12 +25,10 @@ from vernamveil import VernamVeil
 
 
 # Step 1: Define a custom key stream function; remember to store this securely
-def fx(i: int, seed: bytes, bound: int | None) -> int:
+def fx(i: int, seed: bytes) -> int:
     # Simple but cryptographically unsafe fx; see below for a more complex example
     b = seed[i % len(seed)]
     result = ((i ** 2 + i * b + b ** 2) * (i + 7))
-    if bound is not None:
-        result %= bound
     return result
 
 
@@ -49,10 +47,9 @@ decrypted, _ = cypher.decode(encrypted, initial_seed)
 
 **VernamVeil** is an experimental cypher inspired by the **One-Time Pad (OTP)** developed in Python. The name honours **Gilbert Vernam**, who is credited with the theoretical foundation of the OTP.
 
-Instead of using a static key, VernamVeil allows the key to be represented by a function `fx(i: int | np.ndarray[np.uint64], seed: bytes, bound: int | None) -> bytes | np.ndarray[np.uint8]`:
+Instead of using a static key, VernamVeil allows the key to be represented by a function `fx(i: int | np.ndarray[np.uint64], seed: bytes) -> bytes | np.ndarray[np.uint8]`:
 - `i`: the index of the bytes in the message; a scalar integer or an uint64 NumPy array with a continuous enumeration for vectorised operations.
 - `seed`: a byte string that provides context and state; should be kept secret.
-- `bound`: an optional integer used to modulo the function output into the desired range (usually `2**64` because we sample 8 bytes at a time).
 - **Output**: bytes or uint8 NumPy array representing the key stream values.
 
 _Note: `numpy` is an optional but highly recommended dependency, used to accelerate vectorised operations when available._
@@ -163,7 +160,6 @@ When creating your own key stream function (`fx`), it is essential to follow bes
 
 - **Uniform & Non-Constant Output**: Your `fx` should produce diverse, unpredictable outputs for different input indices. Avoid constant, biased, low-entropy, or periodic mathematical functions. The distribution of outputs should be as uniform as possible.
 - **Seed Sensitivity**: The output of `fx` must depend on the secret seed. Changing the seed should result in completely different outputs.
-- **Respect the Bound**: Always ensure that the output of `fx` is within the range `[0, bound)`, where `bound` is provided as an argument.
 - **Type Correctness**: The function must return an `int` (or a NumPy `uint64` array in vectorised mode).
 - **Determinism**: `fx` must be deterministic for the same inputs. Do not use external state or randomness inside your function.
 - **Avoid Data-Dependent Branching or Timing**: Do not introduce data-dependent branching or timing in your `fx`, as this can lead to side-channel attacks.
@@ -182,7 +178,7 @@ Below we provide some example `fx` methods to illustrate these principles in pra
 import hmac
 
 
-def fx(i: int, seed: bytes, bound: int | None) -> int:
+def fx(i: int, seed: bytes) -> int:
     # Implements a customisable fx function based on a 10-degree polynomial transformation of the index,
     # followed by a cryptographically secure HMAC-Blake2b output. 
     # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the HMAC.
@@ -200,10 +196,6 @@ def fx(i: int, seed: bytes, bound: int | None) -> int:
     # Cryptographic HMAC using Blake2b
     hash_result = hmac.new(seed, result.to_bytes(8, "big"), digestmod="blake2b").digest()
     result = int.from_bytes(hash_result, "big")
-    
-    # Modulo the result with the bound to ensure it's always within the requested range
-    if bound is not None:
-        result %= bound
 
     return result
 ```
@@ -211,11 +203,11 @@ def fx(i: int, seed: bytes, bound: int | None) -> int:
 ### 🏎️ A fast version of the above `fx` that uses NumPy vectorisation and the `nphash` C module
 
 ```python
-from vernamveil import fold_bytes_to_uint64, hash_numpy
+from vernamveil import hash_numpy
 import numpy as np
 
 
-def fx(i: np.ndarray, seed: bytes, bound: int | None) -> np.ndarray:
+def fx(i: np.ndarray, seed: bytes) -> np.ndarray:
     # Implements a customisable fx function based on a 10-degree polynomial transformation of the index,
     # followed by a cryptographically secure HMAC-Blake2b output. 
     # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the HMAC.
@@ -229,12 +221,7 @@ def fx(i: np.ndarray, seed: bytes, bound: int | None) -> np.ndarray:
     result = np.dot(powers, weights)
 
     # Cryptographic HMAC using Blake2b
-    hash_result = hash_numpy(result, seed, "blake2b")  # uses C module if available, else NumPy fallback
-    result = fold_bytes_to_uint64(hash_result)
-
-    # Modulo the result with the bound to ensure it's always within the requested range
-    if bound is not None:
-        np.remainder(result, bound, out=result)
+    result = hash_numpy(result, seed, "blake2b")  # uses C module if available, else NumPy fallback
     
     return result
 ```
@@ -242,22 +229,17 @@ def fx(i: np.ndarray, seed: bytes, bound: int | None) -> np.ndarray:
 ### 🛡️ A cryptographically strong HMAC-SHA256 `fx` (vectorised & C-accelerated)
 
 ```python
-from vernamveil import fold_bytes_to_uint64, hash_numpy
+from vernamveil import hash_numpy
 import numpy as np
 
 
-def fx(i: np.ndarray, seed: bytes, bound: int | None) -> np.ndarray:
+def fx(i: np.ndarray, seed: bytes) -> np.ndarray:
     # Implements a standard HMAC-based pseudorandom function (PRF) using sha256.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
     # Security relies entirely on the secrecy of the seed and the cryptographic strength of HMAC.
 
     # Cryptographic HMAC using sha256
-    hash_result = hash_numpy(i, seed, "sha256")  # uses C module if available, else NumPy fallback
-    result = fold_bytes_to_uint64(hash_result)
-
-    # Modulo the result with the bound to ensure it's always within the requested range
-    if bound is not None:
-        np.remainder(result, bound, out=result)
+    result = hash_numpy(i, seed, "sha256")  # uses C module if available, else NumPy fallback
 
     return result
 ```
@@ -268,7 +250,7 @@ def fx(i: np.ndarray, seed: bytes, bound: int | None) -> np.ndarray:
 
 VernamVeil includes helper tools to make working with key stream functions easier:
 
-- `check_fx_sanity`: Runs basic sanity checks on your custom `fx` to ensure it produces diverse, seed-sensitive, and well-bounded outputs.
+- `check_fx_sanity`: Runs basic sanity checks on your custom `fx` to ensure it produces diverse and seed-sensitive outputs.
 - `generate_default_fx` (same as `generate_polynomial_fx`): Generates a random `fx` function that first transforms the index using a polynomial with random weights, then applies HMAC (Blake2b) for cryptographic output. Supports both scalar and vectorised (NumPy) modes.
 - `generate_hmac_fx`: Generates a deterministic `fx` function that applies HMAC (using a specified hash algorithm, e.g., BLAKE2b or SHA-256) directly to the index and seed. The seed is the only secret key but HMAC is a cryptographically strong and proven `fx`. Supports both scalar and vectorised (NumPy) modes.
 - `load_fx_from_file`: Loads a custom `fx` function from a Python file. This is useful for testing and validating your own implementations. This uses `exec` internally to execute the file's code. **Never use this with files from untrusted sources, as it can run arbitrary code on your system.**
@@ -289,9 +271,8 @@ print("Generated fx source code:\n", fx._source_code)
 
 # Check if the generated fx passes basic sanity checks
 seed = b"mysecretseed"
-bound = 256
 num_samples = 100
-passed = check_fx_sanity(fx, seed, bound, num_samples)
+passed = check_fx_sanity(fx, seed, num_samples)
 print("Sanity check passed:", passed)
 ```
 

--- a/README.md
+++ b/README.md
@@ -239,11 +239,11 @@ from vernamveil import FX, hash_numpy
 
 
 def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
-    # Implements a standard HMAC-based pseudorandom function (PRF) using blake2b.
+    # Implements a standard HMAC-based pseudorandom function (PRF) using sha256.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
     # Security relies entirely on the secrecy of the seed and the cryptographic strength of HMAC.
-    # Cryptographic HMAC using blake2b
-    return hash_numpy(i, seed, "blake2b")  # uses C module if available, else NumPy fallback
+    # Cryptographic HMAC using sha256
+    return hash_numpy(i, seed, "sha256")  # uses C module if available, else NumPy fallback
 
 
 fx = FX(keystream_fn, block_size=64, vectorise=True)

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ When creating your own key stream function (`fx`), it is essential to follow bes
 
 - **Uniform & Non-Constant Output**: Your `fx` should produce diverse, unpredictable outputs for different input indices. Avoid constant, biased, low-entropy, or periodic mathematical functions. The distribution of outputs should be as uniform as possible.
 - **Seed Sensitivity**: The output of `fx` must depend on the secret seed. Changing the seed should result in completely different outputs.
-- **Type Correctness**: The function must return an `int` (or a NumPy `uint64` array in vectorised mode).
+- **Type Correctness**: The function must return a `bytes` or a NumPy `uint8` array in vectorised mode.
 - **Determinism**: `fx` must be deterministic for the same inputs. Do not use external state or randomness inside your function.
 - **Avoid Data-Dependent Branching or Timing**: Do not introduce data-dependent branching or timing in your `fx`, as this can lead to side-channel attacks.
 - **Performance**: Complex or slow `fx` functions will slow down encryption and decryption. Test performance if speed is important for your use case.
@@ -242,6 +242,7 @@ def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
     # Implements a standard HMAC-based pseudorandom function (PRF) using sha256.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
     # Security relies entirely on the secrecy of the seed and the cryptographic strength of HMAC.
+
     # Cryptographic HMAC using sha256
     return hash_numpy(i, seed, "sha256")  # uses C module if available, else NumPy fallback
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Instead of using a static key, VernamVeil allows the key to be represented by a 
 - `i`: the index of the bytes in the message; a scalar integer or an uint64 NumPy array with a continuous enumeration for vectorised operations.
 - `seed`: a byte string that provides context and state; should be kept secret.
 - `bound`: an optional integer used to modulo the function output into the desired range (usually `2**64` because we sample 8 bytes at a time).
-- **Output**: an integer or an uint64 NumPy array representing the key stream values.
+- **Output**: an integer or bytes or an uint64/uint8 NumPy array representing the key stream values.
 
 _Note: `numpy` is an optional but highly recommended dependency, used to accelerate vectorised operations when available._
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ def keystream_fn(i: int, seed: bytes) -> int:
     result &= 0xFFFFFFFFFFFFFFFF
     return result.to_bytes(8, "big")
 
-fx = FX(keystream_fn, 8, vectorise=False)
+fx = FX(keystream_fn, block_size=8, vectorise=False)
 
 
 # Step 2: Generate a random initial seed for encryption

--- a/docs/fx_utilities.rst
+++ b/docs/fx_utilities.rst
@@ -3,10 +3,17 @@ Fx Utilities
 
 .. currentmodule:: vernamveil
 
+.. autoclass:: FX
+   :members:
+   :undoc-members:
+   :inherited-members:
+   :show-inheritance:
 
+.. autofunction:: check_fx_sanity
 .. py:function:: generate_default_fx(*args, **kwargs)
 
    Alias for :func:`vernamveil.generate_polynomial_fx`.
 
 .. autofunction:: generate_polynomial_fx
 .. autofunction:: generate_hmac_fx
+.. autofunction:: load_fx_from_file

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,7 +72,7 @@ from vernamveil import FX
 def keystream_fn(i, seed):
     return hmac.new(seed, i.to_bytes(8, "big"), digestmod="blake2b").digest()
 
-fx = FX(keystream_fn, 8, vectorise=False)
+fx = FX(keystream_fn, 64, vectorise=False)
 """
 
     def tearDown(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import os
 import random
 import re
 import shutil
-import sys  # noqa: F401
+import sys
 import tempfile
 import unittest
 from contextlib import contextmanager

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,7 +63,7 @@ def keystream_fn(i, seed):
     v &= 0xFFFFFFFFFFFFFFFF
     return v.to_bytes(8, "big")
 
-fx = FX(keystream_fn, 8, vectorise=False)
+fx = FX(keystream_fn, block_size=8, vectorise=False)
 """
         self.fx_strong_code = """
 import hmac
@@ -72,7 +72,7 @@ from vernamveil import FX
 def keystream_fn(i, seed):
     return hmac.new(seed, i.to_bytes(8, "big"), digestmod="blake2b").digest()
 
-fx = FX(keystream_fn, 64, vectorise=False)
+fx = FX(keystream_fn, block_size=64, vectorise=False)
 """
 
     def tearDown(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,15 +57,14 @@ class TestVernamVeilCLI(unittest.TestCase):
         self.outfile = self.temp_dir_path / "output.txt"
         self.fx_code = """
 def fx(i, seed):
-    h = i + 1
-    return h
+    v = i + 1
+    return v.to_bytes((v.bit_length() + 7) // 8, "big")
 """
         self.fx_strong_code = """
 import hmac
 
 def fx(i, seed):
-    h = int.from_bytes(hmac.new(seed, i.to_bytes(8, "big"), digestmod="blake2b").digest(), "big")
-    return h
+    return hmac.new(seed, i.to_bytes(8, "big"), digestmod="blake2b").digest()
 """
 
     def tearDown(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,16 +56,16 @@ class TestVernamVeilCLI(unittest.TestCase):
         self.encfile = self.temp_dir_path / "output.enc"
         self.outfile = self.temp_dir_path / "output.txt"
         self.fx_code = """
-def fx(i, seed, bound):
+def fx(i, seed):
     h = i + 1
-    return h % bound if bound is not None else h
+    return h
 """
         self.fx_strong_code = """
 import hmac
 
-def fx(i, seed, bound):
+def fx(i, seed):
     h = int.from_bytes(hmac.new(seed, i.to_bytes(8, "big"), digestmod="blake2b").digest(), "big")
-    return h % bound if bound is not None else h
+    return h
 """
 
     def tearDown(self):

--- a/tests/test_deniability_utils.py
+++ b/tests/test_deniability_utils.py
@@ -13,11 +13,11 @@ class TestDeniabilityUtils(unittest.TestCase):
 
     def _run_deniability_test(
         self,
-        chunk_size=31,
-        delimiter_size=9,
-        padding_range=(5, 15),
-        decoy_ratio=0.2,
-        vectorise=False,
+        chunk_size,
+        delimiter_size,
+        padding_range,
+        decoy_ratio,
+        vectorise,
     ):
         """Utility to run a basic deniability test with configurable parameters."""
         real_fx = generate_default_fx(vectorise=vectorise)
@@ -61,8 +61,8 @@ class TestDeniabilityUtils(unittest.TestCase):
 
     def test_plausible_fx_source_code_roundtrip(self):
         """Test that _PlausibleFX source code can be saved and loaded, preserving integers."""
-        test_ints = [42, 99, 123456, 7, 0]
-        fx = _PlausibleFX(test_ints)
+        test_keystream = [b"42", b"99", b"123456", b"7", b"0"]
+        fx = _PlausibleFX(test_keystream)
         source_code = fx._source_code
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -70,8 +70,8 @@ class TestDeniabilityUtils(unittest.TestCase):
             with open(path, "w") as f:
                 f.write(source_code)
             loaded_fx = load_fx_from_file(str(path))
-            self.assertTrue(hasattr(loaded_fx, "_uint64s"))
-            self.assertEqual(list(loaded_fx._uint64s), test_ints)
+            self.assertTrue(hasattr(loaded_fx, "_keystream"))
+            self.assertEqual(list(loaded_fx._keystream), test_keystream)
 
     def test_end_to_end_deniability_disk_io(self):
         """End-to-end test: store/load all artifacts and verify deniability."""
@@ -80,8 +80,8 @@ class TestDeniabilityUtils(unittest.TestCase):
         secret_message = b"Sensitive data: the launch code is 12345!"
         cypher = VernamVeil(
             real_fx,
-            chunk_size=32,
-            delimiter_size=8,
+            chunk_size=33,
+            delimiter_size=9,
             padding_range=(5, 15),
             decoy_ratio=0.2,
             siv_seed_initialisation=True,
@@ -140,8 +140,8 @@ class TestDeniabilityUtils(unittest.TestCase):
             # Decrypt with real fx/seed
             real_cypher = VernamVeil(
                 loaded_real_fx,
-                chunk_size=32,
-                delimiter_size=8,
+                chunk_size=33,
+                delimiter_size=9,
                 padding_range=(5, 15),
                 decoy_ratio=0.2,
                 siv_seed_initialisation=True,
@@ -153,8 +153,8 @@ class TestDeniabilityUtils(unittest.TestCase):
             # Decrypt with plausible fx/fake seed
             fake_cypher = VernamVeil(
                 loaded_plausible_fx,
-                chunk_size=32,
-                delimiter_size=8,
+                chunk_size=33,
+                delimiter_size=9,
                 padding_range=(5, 15),
                 decoy_ratio=0.2,
                 siv_seed_initialisation=False,
@@ -168,8 +168,8 @@ class TestDeniabilityUtils(unittest.TestCase):
 
 
 # Generate all combinations
-chunk_sizes = [31, 32, 33]
-delimiter_sizes = [7, 8, 9]
+chunk_sizes = [127, 128, 129]
+delimiter_sizes = [7, 8, 9, 63, 64, 65]
 combos = list(itertools.product(chunk_sizes, delimiter_sizes))
 
 
@@ -185,7 +185,7 @@ def make_test_func(chunk_size, delimiter_size):
                     decoy_out, decoy_message = self._run_deniability_test(
                         chunk_size=chunk_size,
                         delimiter_size=delimiter_size,
-                        padding_range=(5, 15),
+                        padding_range=(5, 150),
                         decoy_ratio=0.3,
                         vectorise=vectorise,
                     )

--- a/tests/test_fx_utils.py
+++ b/tests/test_fx_utils.py
@@ -34,8 +34,7 @@ class TestFxUtils(unittest.TestCase):
         arr = np.arange(10, dtype=np.uint64)
         out = fx(arr, self.seed)
         self.assertIsInstance(out, np.ndarray)
-        self.assertEqual(out.shape[0], arr.shape[0])
-        self.assertTrue((out >= 0).all())
+        self.assertEqual(out.shape, (arr.shape[0], fx.block_size))
 
     def test_check_fx_sanity_constant_function(self):
         """Test check_fx_sanity fails and warns for a constant fx."""
@@ -50,9 +49,7 @@ class TestFxUtils(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
-        self.assertTrue(
-            any("constant" in str(warn.message) or "low-entropy" in str(warn.message) for warn in w)
-        )
+        self.assertTrue(any("constant" in str(warn.message) for warn in w))
 
     def test_check_fx_sanity_seed_insensitive(self):
         """Test check_fx_sanity fails and warns for a seed-insensitive fx."""
@@ -67,7 +64,7 @@ class TestFxUtils(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
-        self.assertTrue(any("seed" in str(warn.message) for warn in w))
+        self.assertTrue(any("does not depend on seed" in str(warn.message) for warn in w))
 
     def test_check_fx_sanity_uniformity_violation(self):
         """Test check_fx_sanity fails and warns for fx that is heavily biased."""

--- a/tests/test_fx_utils.py
+++ b/tests/test_fx_utils.py
@@ -12,42 +12,43 @@ except ImportError:
     pass
 
 
+# TODO: rewrite all check_fx_sanity tests to use bytes
+
+
 class TestFxUtils(unittest.TestCase):
     """Unit tests for the fx_utils.py utilities."""
 
     def setUp(self):
         """Set up common test parameters."""
         self.seed = b"testseed"
-        self.bound = 256
         self.num_samples = 100
 
     def test_generate_default_fx_scalar(self):
         """Test that generate_default_fx returns a valid scalar function."""
         fx = generate_default_fx(vectorise=False)
         for i in range(10):
-            out = fx(i, self.seed, self.bound)
+            out = fx(i, self.seed)
             self.assertIsInstance(out, int)
             self.assertGreaterEqual(out, 0)
-            self.assertLess(out, self.bound)
 
     @unittest.skipUnless(_HAS_NUMPY, "NumPy not available")
     def test_generate_default_fx_vectorised(self):
         """Test that generate_default_fx returns a valid vectorised function."""
         fx = generate_default_fx(vectorise=True)
         arr = np.arange(10, dtype=np.uint64)
-        out = fx(arr, self.seed, self.bound)
+        out = fx(arr, self.seed)
         self.assertIsInstance(out, np.ndarray)
-        self.assertEqual(out.shape, arr.shape)
-        self.assertTrue((out >= 0).all() and (out < self.bound).all())
+        self.assertEqual(out.shape[0], arr.shape[0])
+        self.assertTrue((out >= 0).all())
 
     def test_check_fx_sanity_constant_function(self):
         """Test check_fx_sanity fails and warns for a constant fx."""
 
-        def fx(i, seed, bound):
+        def fx(i, seed):
             return 42
 
         with warnings.catch_warnings(record=True) as w:
-            passed = check_fx_sanity(fx, self.seed, self.bound, self.num_samples)
+            passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
         self.assertTrue(
             any("constant" in str(warn.message) or "low-entropy" in str(warn.message) for warn in w)
@@ -56,33 +57,22 @@ class TestFxUtils(unittest.TestCase):
     def test_check_fx_sanity_seed_insensitive(self):
         """Test check_fx_sanity fails and warns for a seed-insensitive fx."""
 
-        def fx(i, seed, bound):
-            return i % bound
+        def fx(i, seed):
+            return i
 
         with warnings.catch_warnings(record=True) as w:
-            passed = check_fx_sanity(fx, self.seed, self.bound, self.num_samples)
+            passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
         self.assertTrue(any("seed" in str(warn.message) for warn in w))
-
-    def test_check_fx_sanity_bound_violation(self):
-        """Test check_fx_sanity fails and warns for fx that violates the bound."""
-
-        def fx(i, seed, bound):
-            return bound + 1  # Always out of bounds
-
-        with warnings.catch_warnings(record=True) as w:
-            passed = check_fx_sanity(fx, self.seed, self.bound, self.num_samples)
-        self.assertFalse(passed)
-        self.assertTrue(any("bound" in str(warn.message) for warn in w))
 
     def test_check_fx_sanity_uniformity_violation(self):
         """Test check_fx_sanity fails and warns for fx that is heavily biased."""
 
-        def fx(i, seed, bound):
-            return 0 if i < self.num_samples - 1 else 1  # Almost always 0
+        def fx(i, seed):
+            return b"x00" if i < self.num_samples - 1 else b"x01"  # Almost always 0
 
         with warnings.catch_warnings(record=True) as w:
-            passed = check_fx_sanity(fx, self.seed, self.bound, self.num_samples)
+            passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
         self.assertTrue(any("biased" in str(warn.message) for warn in w))
 
@@ -90,7 +80,7 @@ class TestFxUtils(unittest.TestCase):
         """Test check_default_fx_sanity passes for a good scalar default fx."""
         fx = generate_default_fx(vectorise=False)
         with warnings.catch_warnings(record=True) as w:
-            passed = check_fx_sanity(fx, self.seed, self.bound, self.num_samples)
+            passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertTrue(passed)
         self.assertEqual(len(w), 0)
 
@@ -99,7 +89,7 @@ class TestFxUtils(unittest.TestCase):
         """Test check_default_fx_sanity passes for a good vectorised default fx."""
         fx = generate_default_fx(vectorise=True)
         with warnings.catch_warnings(record=True) as w:
-            passed = check_fx_sanity(fx, self.seed, self.bound, self.num_samples)
+            passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertTrue(passed)
         self.assertEqual(len(w), 0)
 
@@ -114,7 +104,7 @@ class TestFxUtils(unittest.TestCase):
         try:
             fx_loaded = load_fx_from_file(tmp_path)
             self.assertTrue(callable(fx_loaded))
-            self.assertTrue(isinstance(fx_loaded(1, bytes(), self.bound), int))
+            self.assertTrue(isinstance(fx_loaded(1, bytes()), int))
         finally:
             tmp_path.unlink()
 
@@ -131,9 +121,7 @@ class TestFxUtils(unittest.TestCase):
             fx_loaded = load_fx_from_file(tmp_path)
             self.assertTrue(callable(fx_loaded))
             self.assertTrue(
-                isinstance(
-                    fx_loaded(np.arange(1, 10, dtype=np.uint64), bytes(), self.bound), np.ndarray
-                )
+                isinstance(fx_loaded(np.arange(1, 10, dtype=np.uint64), bytes()), np.ndarray)
             )
         finally:
             tmp_path.unlink()

--- a/tests/test_fx_utils.py
+++ b/tests/test_fx_utils.py
@@ -43,7 +43,7 @@ class TestFxUtils(unittest.TestCase):
         def keystream_fn(i, seed):
             return 42
 
-        fx = FX(keystream_fn, 8, vectorise=False)
+        fx = FX(keystream_fn, block_size=8, vectorise=False)
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
@@ -57,7 +57,7 @@ class TestFxUtils(unittest.TestCase):
             # Wrong shape: should be (num_samples, block_size)
             return np.zeros((self.num_samples, 1), dtype=np.uint8)
 
-        fx = FX(keystream_fn, 8, vectorise=True)
+        fx = FX(keystream_fn, block_size=8, vectorise=True)
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
@@ -69,7 +69,7 @@ class TestFxUtils(unittest.TestCase):
         def keystream_fn(i, seed):
             return b"x" * (8 if i % 2 == 0 else 7)  # Odd indices have wrong length
 
-        fx = FX(keystream_fn, 8, vectorise=False)
+        fx = FX(keystream_fn, block_size=8, vectorise=False)
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
@@ -81,7 +81,7 @@ class TestFxUtils(unittest.TestCase):
         def keystream_fn(i, seed):
             return b"x" * 8
 
-        fx = FX(keystream_fn, 8, vectorise=False)
+        fx = FX(keystream_fn, block_size=8, vectorise=False)
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
@@ -95,7 +95,7 @@ class TestFxUtils(unittest.TestCase):
         def keystream_fn(i, seed):
             return (i.to_bytes(8, "big") * 1)[:8]
 
-        fx = FX(keystream_fn, 8, vectorise=False)
+        fx = FX(keystream_fn, block_size=8, vectorise=False)
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
@@ -107,7 +107,7 @@ class TestFxUtils(unittest.TestCase):
         def keystream_fn(i, seed):
             return b"\x00" * 8 if i < self.num_samples - 1 else b"\x01" * 8
 
-        fx = FX(keystream_fn, 8, vectorise=False)
+        fx = FX(keystream_fn, block_size=8, vectorise=False)
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
@@ -119,7 +119,7 @@ class TestFxUtils(unittest.TestCase):
         def keystream_fn(i, seed):
             return b"\x00" * 8
 
-        fx = FX(keystream_fn, 8, vectorise=False)
+        fx = FX(keystream_fn, block_size=8, vectorise=False)
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
@@ -132,7 +132,7 @@ class TestFxUtils(unittest.TestCase):
             # Only the LSB changes, rest is constant
             return (b"\x00" * 7) + bytes([i & 1])
 
-        fx = FX(keystream_fn, 8, vectorise=False)
+        fx = FX(keystream_fn, block_size=8, vectorise=False)
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
         self.assertFalse(passed)
@@ -234,7 +234,7 @@ class TestFxUtils(unittest.TestCase):
 
         with patch("vernamveil._fx_utils._HAS_NUMPY", False):
             with self.assertRaises(ValueError):
-                FX(keystream_fn, 8, vectorise=True)
+                FX(keystream_fn, block_size=8, vectorise=True)
 
     def test_warns_if_numpy_present_but_vectorise_false(self):
         """Test that FX warns if numpy is present but vectorise is False."""
@@ -244,7 +244,7 @@ class TestFxUtils(unittest.TestCase):
 
         with patch("vernamveil._fx_utils._HAS_NUMPY", True):
             with warnings.catch_warnings(record=True) as w:
-                FX(keystream_fn, 8, vectorise=False)
+                FX(keystream_fn, block_size=8, vectorise=False)
             self.assertTrue(any("NumPy will not be used" in str(warn.message) for warn in w))
 
 

--- a/tests/test_fx_utils.py
+++ b/tests/test_fx_utils.py
@@ -12,9 +12,6 @@ except ImportError:
     pass
 
 
-# TODO: rewrite all check_fx_sanity tests to use bytes
-
-
 class TestFxUtils(unittest.TestCase):
     """Unit tests for the fx_utils.py utilities."""
 
@@ -28,8 +25,7 @@ class TestFxUtils(unittest.TestCase):
         fx = generate_default_fx(vectorise=False)
         for i in range(10):
             out = fx(i, self.seed)
-            self.assertIsInstance(out, int)
-            self.assertGreaterEqual(out, 0)
+            self.assertIsInstance(out, bytes)
 
     @unittest.skipUnless(_HAS_NUMPY, "NumPy not available")
     def test_generate_default_fx_vectorised(self):
@@ -45,7 +41,8 @@ class TestFxUtils(unittest.TestCase):
         """Test check_fx_sanity fails and warns for a constant fx."""
 
         def fx(i, seed):
-            return 42
+            v = 42
+            return v.to_bytes((v.bit_length() + 7) // 8, "big")
 
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
@@ -58,7 +55,7 @@ class TestFxUtils(unittest.TestCase):
         """Test check_fx_sanity fails and warns for a seed-insensitive fx."""
 
         def fx(i, seed):
-            return i
+            return i.to_bytes((i.bit_length() + 7) // 8, "big")
 
         with warnings.catch_warnings(record=True) as w:
             passed = check_fx_sanity(fx, self.seed, self.num_samples)
@@ -104,7 +101,7 @@ class TestFxUtils(unittest.TestCase):
         try:
             fx_loaded = load_fx_from_file(tmp_path)
             self.assertTrue(callable(fx_loaded))
-            self.assertTrue(isinstance(fx_loaded(1, bytes()), int))
+            self.assertTrue(isinstance(fx_loaded(1, bytes()), bytes))
         finally:
             tmp_path.unlink()
 

--- a/tests/test_hash_utils.py
+++ b/tests/test_hash_utils.py
@@ -4,7 +4,7 @@ import secrets
 import unittest
 from unittest.mock import patch
 
-from vernamveil._hash_utils import _HAS_C_MODULE, _UINT64_BOUND, fold_bytes_to_uint64, hash_numpy
+from vernamveil._hash_utils import _HAS_C_MODULE, fold_bytes_to_uint64, hash_numpy
 from vernamveil._vernamveil import _HAS_NUMPY
 
 try:
@@ -56,7 +56,7 @@ class TestHashUtils(unittest.TestCase):
                                     seed, i_bytes[j : j + 8], digestmod=method
                                 ).digest()
                                 if fold_type == "full":
-                                    return int.from_bytes(digest, "big") % _UINT64_BOUND
+                                    return int.from_bytes(digest, "big") % 2**64
                                 else:  # "view"
                                     return int.from_bytes(digest[:8], "big")
 
@@ -95,7 +95,7 @@ class TestHashUtils(unittest.TestCase):
                             def get_digest(j):
                                 digest = method(i_bytes[j : j + 8]).digest()
                                 if fold_type == "full":
-                                    return int.from_bytes(digest, "big") % _UINT64_BOUND
+                                    return int.from_bytes(digest, "big") % 2**64
                                 else:  # "view"
                                     return int.from_bytes(digest[:8], "big")
 

--- a/tests/test_hash_utils.py
+++ b/tests/test_hash_utils.py
@@ -4,8 +4,8 @@ import secrets
 import unittest
 from unittest.mock import patch
 
+from vernamveil._cypher import _HAS_NUMPY
 from vernamveil._hash_utils import _HAS_C_MODULE, fold_bytes_to_uint64, hash_numpy
-from vernamveil._vernamveil import _HAS_NUMPY
 
 try:
     import numpy as np

--- a/tests/test_vernamveil.py
+++ b/tests/test_vernamveil.py
@@ -7,9 +7,10 @@ from contextlib import nullcontext
 from pathlib import Path
 from unittest.mock import patch
 
+from vernamveil._cypher import _HAS_NUMPY
 from vernamveil._fx_utils import generate_default_fx
 from vernamveil._hash_utils import _HAS_C_MODULE
-from vernamveil._vernamveil import _HAS_NUMPY, VernamVeil
+from vernamveil._vernamveil import VernamVeil
 
 
 def get_test_modes():
@@ -44,7 +45,7 @@ class TestVernamVeil(unittest.TestCase):
                 )
                 with context:
                     fx = generate_default_fx(vectorise=vectorise)
-                    cypher = VernamVeil(fx, vectorise=vectorise, **cypher_kwargs)
+                    cypher = VernamVeil(fx, **cypher_kwargs)
                     test_func(cypher, vectorise)
 
     def test_single_message_encryption(self):

--- a/vernamveil/__init__.py
+++ b/vernamveil/__init__.py
@@ -4,6 +4,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 from vernamveil._deniability_utils import forge_plausible_fx
 from vernamveil._fx_utils import (
+    FX,
     check_fx_sanity,
     generate_default_fx,
     generate_hmac_fx,
@@ -22,6 +23,7 @@ except PackageNotFoundError:
 
 __all__ = [
     "__version__",
+    "FX",
     "VernamVeil",
     "check_fx_sanity",
     "fold_bytes_to_uint64",

--- a/vernamveil/_cypher.py
+++ b/vernamveil/_cypher.py
@@ -6,7 +6,23 @@ import stat
 import threading
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import IO, Callable, Literal
+from typing import IO, Any, Callable, Literal
+
+np: Any
+_Integer: Any
+_Bytes: Any
+try:
+    import numpy
+
+    np = numpy
+    _Integer = int | np.ndarray[np.uint64]
+    _Bytes = bytes | np.ndarray[np.uint8]
+    _HAS_NUMPY = True
+except ImportError:
+    np = None
+    _Integer = int
+    _Bytes = bytes
+    _HAS_NUMPY = False
 
 __all__: list[str] = []
 

--- a/vernamveil/_deniability_utils.py
+++ b/vernamveil/_deniability_utils.py
@@ -10,7 +10,7 @@ import copy
 import math
 from typing import Any
 
-from vernamveil._vernamveil import VernamVeil, _IntOrArray, _IntOrBytes
+from vernamveil._vernamveil import VernamVeil, _Bytes, _Integer
 
 np: Any
 try:
@@ -112,16 +112,16 @@ fx = _PlausibleFX({keystream})
 
 """
 
-    def __call__(self, i: _IntOrArray, _: bytes, __: int | None = None) -> _IntOrBytes:
+    def __call__(self, i: _Integer, _: bytes, __: int | None = None) -> _Bytes:
         """Generates the next value in the fake keystream.
 
         Args:
-            i (_IntOrArray): the index of the bytes in the message.
+            i (_Integer): the index of the bytes in the message.
             _ (bytes): Unused parameter for compatibility.
             __ (int, optional): Unused parameter for compatibility.
 
         Returns:
-            _IntOrBytes: The next value in the fake keystream.
+            _Bytes: The next value in the fake keystream.
         """
         use_numpy = np is not None and isinstance(i, np.ndarray)
 

--- a/vernamveil/_fx_utils.py
+++ b/vernamveil/_fx_utils.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any, Callable, Literal, cast
 
 from vernamveil._hash_utils import _UINT64_BOUND, fold_bytes_to_uint64, hash_numpy
-from vernamveil._vernamveil import _IntOrArray
+from vernamveil._vernamveil import _IntOrArray, _IntOrBytes
 
 np: Any
 try:
@@ -33,7 +33,7 @@ __all__ = [
 def generate_hmac_fx(
     hash_name: Literal["blake2b", "sha256"] = "blake2b",
     vectorise: bool = False,
-) -> Callable[[_IntOrArray, bytes, int | None], _IntOrArray]:
+) -> Callable[[_IntOrArray, bytes, int | None], _IntOrBytes]:
     """Generate a standard HMAC-based pseudorandom function (PRF) using Blake2b or SHA256.
 
     Args:
@@ -41,7 +41,7 @@ def generate_hmac_fx(
         vectorise (bool): If True, uses numpy arrays as input for vectorised operations.
 
     Returns:
-        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray]: A function that returns pseudo-random
+        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray | bytes]: A function that returns pseudo-random
             integers from HMAC-based function.
 
     Raises:
@@ -67,11 +67,13 @@ def fx(i: np.ndarray, seed: bytes, bound: int | None) -> np.ndarray:
 
     # Cryptographic HMAC using {hash_name}
     hash_result = hash_numpy(i, seed, "{hash_name}")  # uses C module if available, else NumPy fallback
-    result = fold_bytes_to_uint64(hash_result)
 
-    # Modulo the result with the bound to ensure it's always within the requested range
+    # Convert to uint64 and modulo the result with the bound to ensure it's always within the requested range
     if bound is not None:
+        result = fold_bytes_to_uint64(hash_result)
         np.remainder(result, bound, out=result)
+    else:
+        result = hash_result
 
     return result
 """
@@ -112,12 +114,12 @@ def fx(i: int, seed: bytes, bound: int | None) -> int:
     fx = local_vars["fx"]
     fx._source_code = function_code
 
-    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrArray], fx)
+    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrBytes], fx)
 
 
 def generate_polynomial_fx(
     degree: int = 10, max_weight: int = 10**5, vectorise: bool = False
-) -> Callable[[_IntOrArray, bytes, int | None], _IntOrArray]:
+) -> Callable[[_IntOrArray, bytes, int | None], _IntOrBytes]:
     """Generate a random polynomial-based secret function to act as a deterministic key stream generator.
 
     The transformed input index is passed to a cryptographic hash function (HMAC) and bounded to the requested range.
@@ -130,7 +132,7 @@ def generate_polynomial_fx(
         vectorise (bool): If True, uses numpy arrays as input for vectorised operations.
 
     Returns:
-        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray]: A function that returns pseudo-random
+        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray | bytes]: A function that returns pseudo-random
             integers from polynomial evaluation.
 
     Raises:
@@ -176,11 +178,13 @@ def fx(i: np.ndarray, seed: bytes, bound: int | None) -> np.ndarray:
 
     # Cryptographic HMAC using Blake2b
     hash_result = hash_numpy(result, seed, "blake2b")  # uses C module if available, else NumPy fallback
-    result = fold_bytes_to_uint64(hash_result)
 
-    # Modulo the result with the bound to ensure it's always within the requested range
+    # Convert to uint64 and modulo the result with the bound to ensure it's always within the requested range
     if bound is not None:
+        result = fold_bytes_to_uint64(hash_result)
         np.remainder(result, bound, out=result)
+    else:
+        result = hash_result
 
     return result
 """
@@ -232,32 +236,32 @@ def fx(i: int, seed: bytes, bound: int | None) -> int:
     # Attach the code string directly to the function object for later reference
     fx._source_code = function_code
 
-    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrArray], fx)
+    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrBytes], fx)
 
 
 # Default function for key stream generation
 generate_default_fx = generate_polynomial_fx
 
 
-def load_fx_from_file(path: str | Path) -> Callable[[_IntOrArray, bytes, int | None], _IntOrArray]:
+def load_fx_from_file(path: str | Path) -> Callable[[_IntOrArray, bytes, int | None], _IntOrBytes]:
     """Load the fx function from a Python file.
 
     Args:
         path (str | Path): Path to the Python file containing fx.
 
     Returns:
-        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray]: The loaded fx function.
+        Callable[[int | np.ndarray, bytes, int | None], int | np.ndarray | bytes]: The loaded fx function.
     """
     global_vars: dict[str, Any] = {}
     path_obj = Path(path)
     code = path_obj.read_text()
     exec(code, global_vars)
     fx = global_vars["fx"]
-    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrArray], fx)
+    return cast(Callable[[_IntOrArray, bytes, int | None], _IntOrBytes], fx)
 
 
 def check_fx_sanity(
-    fx: Callable[[_IntOrArray, bytes, int | None], _IntOrArray],
+    fx: Callable[[_IntOrArray, bytes, int | None], _IntOrBytes],
     seed: bytes,
     bound: int = 256,
     num_samples: int = 1000,

--- a/vernamveil/_hash_utils.py
+++ b/vernamveil/_hash_utils.py
@@ -16,9 +16,6 @@ try:
 except ImportError:
     _HAS_C_MODULE = False
 
-
-_UINT64_BOUND = 2**64
-
 __all__ = ["fold_bytes_to_uint64", "hash_numpy"]
 
 

--- a/vernamveil/_hash_utils.py
+++ b/vernamveil/_hash_utils.py
@@ -26,7 +26,7 @@ def fold_bytes_to_uint64(
     """Fold each row of a 2D uint8 hash output into a uint64 integer (big-endian).
 
     Args:
-        hashes (np.ndarray[np.uint8]): 2D array of shape (n, H) where H >= 8.
+        hashes (np.ndarray[tuple[int, int], np.dtype[np.uint8]]): 2D array of shape (n, H) where H >= 8.
         fold_type (Literal["full", "view"] = "view"): Folding strategy.
             "view": Fastest; reinterprets the first 8 bytes as uint64.
             "full": Slower; folds all bytes in the row using bitwise operations.
@@ -79,8 +79,8 @@ def hash_numpy(
         hash_name (Literal["blake2b", "sha256"]): Hash algorithm to use. Defaults to "blake2b".
 
     Returns:
-        np.ndarray[np.uint8]: A 2D array of shape (n, H) where H is the hash output size in bytes (32 for sha256, 64 for blake2b).
-            Each row contains the full hash output for the corresponding input.
+        np.ndarray[tuple[int, int], np.dtype[np.uint8]]: A 2D array of shape (n, H) where H is the hash output size in
+            bytes (32 for sha256, 64 for blake2b). Each row contains the full hash output for the corresponding input.
 
     Raises:
         ValueError: If a hash algorithm is not supported.

--- a/vernamveil/_hash_utils.py
+++ b/vernamveil/_hash_utils.py
@@ -9,7 +9,6 @@ from typing import Literal
 
 try:
     import numpy as np
-    from numpy.typing import NDArray
 
     from nphash import _npblake2bffi, _npsha256ffi
 
@@ -24,19 +23,20 @@ __all__ = ["fold_bytes_to_uint64", "hash_numpy"]
 
 
 def fold_bytes_to_uint64(
-    hashes: "NDArray[np.uint8]", fold_type: Literal["full", "view"] = "view"
-) -> "NDArray[np.uint64]":
+    hashes: "np.ndarray[tuple[int, int], np.dtype[np.uint8]]",
+    fold_type: Literal["full", "view"] = "view",
+) -> "np.ndarray[tuple[int], np.dtype[np.uint64]]":
     """Fold each row of a 2D uint8 hash output into a uint64 integer (big-endian).
 
     Args:
-        hashes (NDArray[np.uint8]): 2D array of shape (n, H) where H >= 8.
+        hashes (np.ndarray[np.uint8]): 2D array of shape (n, H) where H >= 8.
         fold_type (Literal["full", "view"] = "view"): Folding strategy.
             "view": Fastest; reinterprets the first 8 bytes as uint64.
             "full": Slower; folds all bytes in the row using bitwise operations.
             Default is "view".
 
     Returns:
-        NDArray[np.uint64]: 1D array of length n, each element is the folded uint64 value of the corresponding row.
+        np.ndarray[tuple[int], np.dtype[np.uint64]]: 1D array of length n, each element is the folded uint64 value of the corresponding row.
 
     Raises:
         ValueError: If the input array is not 2D or has less than 8 columns.
@@ -55,17 +55,19 @@ def fold_bytes_to_uint64(
         hashes_u64 = hashes.astype(np.uint64, copy=False)
 
         # Compute folded values in a fully vectorized way
-        result: NDArray[np.uint64] = np.bitwise_or.reduce(hashes_u64 << shifts, axis=1)
+        result: np.ndarray[tuple[int], np.dtype[np.uint64]] = np.bitwise_or.reduce(
+            hashes_u64 << shifts, axis=1
+        )
         return result
     else:
         raise ValueError(f"Unsupported fold_type '{fold_type}'. Use 'full' or 'view'.")
 
 
 def hash_numpy(
-    i: "NDArray[np.uint64]",
+    i: "np.ndarray[tuple[int], np.dtype[np.uint64]]",
     seed: bytes | None = None,
     hash_name: Literal["blake2b", "sha256"] = "blake2b",
-) -> "NDArray[np.uint8]":
+) -> "np.ndarray[tuple[int, int], np.dtype[np.uint8]]":
     """Compute a 2D uint8 NumPy array by HMAC-ing or hashing each index with a seed using a hashing algorithm.
 
     If no seed is provided, the index is hashed directly.
@@ -75,12 +77,12 @@ def hash_numpy(
     a NumPy fallback is used.
 
     Args:
-        i (NDArray[np.uint64]): NumPy array of indices (dtype should be unsigned 64-bit integer).
+        i (np.ndarray[tuple[int], np.dtype[np.uint64]]): NumPy array of indices (dtype should be unsigned 64-bit integer).
         seed (bytes, optional): The seed bytes used as the HMAC key. If None, hashes only the index.
         hash_name (Literal["blake2b", "sha256"]): Hash algorithm to use. Defaults to "blake2b".
 
     Returns:
-        NDArray[np.uint8]: A 2D array of shape (n, H) where H is the hash output size in bytes (32 for sha256, 64 for blake2b).
+        np.ndarray[np.uint8]: A 2D array of shape (n, H) where H is the hash output size in bytes (32 for sha256, 64 for blake2b).
             Each row contains the full hash output for the corresponding input.
 
     Raises:

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -39,7 +39,7 @@ class VernamVeil(_Cypher):
         """Initialise the VernamVeil encryption cypher with configurable parameters.
 
         Args:
-            fx (FX): A callable objects that generates keystream bytes. This function is critical for the
+            fx (FX): A callable object that generates keystream bytes. This function is critical for the
                 encryption process and should be carefully designed to ensure cryptographic security.
             chunk_size (int): Size of message chunks. Defaults to 32.
             delimiter_size (int): The delimiter size in bytes used for separating chunks; must be

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -8,28 +8,11 @@ import hmac
 import math
 import secrets
 import time
-import warnings
-from typing import Any, Callable, Iterator
+from typing import Any, Iterator
 
-from vernamveil._cypher import _Cypher
+from vernamveil._cypher import _Cypher, np
+from vernamveil._fx_utils import FX
 from vernamveil._hash_utils import fold_bytes_to_uint64, hash_numpy
-
-np: Any
-_Integer: Any
-_Bytes: Any
-try:
-    import numpy
-
-    np = numpy
-    _Integer = int | np.ndarray[np.uint64]
-    _Bytes = bytes | np.ndarray[np.uint8]
-    _HAS_NUMPY = True
-except ImportError:
-    np = None
-    _Integer = int
-    _Bytes = bytes
-    _HAS_NUMPY = False
-
 
 __all__ = ["VernamVeil"]
 
@@ -45,21 +28,19 @@ class VernamVeil(_Cypher):
 
     def __init__(
         self,
-        fx: Callable[[_Integer, bytes], _Bytes],
+        fx: FX,
         chunk_size: int = 32,
         delimiter_size: int = 8,
         padding_range: tuple[int, int] = (5, 15),
         decoy_ratio: float = 0.1,
         siv_seed_initialisation: bool = True,
         auth_encrypt: bool = True,
-        vectorise: bool = False,
     ):
         """Initialise the VernamVeil encryption cypher with configurable parameters.
 
         Args:
-            fx (Callable): Key stream generator accepting (int | np.ndarray[np.uint64], bytes) and returning an
-                bytes or np.ndarray[np.uint8]. This function is critical for the encryption process and should be carefully
-                designed to ensure cryptographic security.
+            fx (FX): A callable objects that generates keystream bytes. This function is critical for the
+                encryption process and should be carefully designed to ensure cryptographic security.
             chunk_size (int): Size of message chunks. Defaults to 32.
             delimiter_size (int): The delimiter size in bytes used for separating chunks; must be
                 at least 4. Defaults to 8.
@@ -69,8 +50,6 @@ class VernamVeil(_Cypher):
             siv_seed_initialisation (bool): Enables synthetic IV seed initialisation based on the message to
                 resist seed reuse. Defaults to True.
             auth_encrypt (bool): Enables authenticated encryption with integrity check. Defaults to True.
-            vectorise (bool): Whether to use numpy for vectorised operations. If True, numpy must be
-                installed and `fx` must support numpy arrays. Defaults to False.
 
         Raises:
             ValueError: If `chunk_size` is less than 8.
@@ -79,7 +58,6 @@ class VernamVeil(_Cypher):
             ValueError: If `padding_range` values are negative.
             ValueError: If `padding_range` values are not in ascending order.
             ValueError: If `decoy_ratio` is negative.
-            ValueError: If `vectorise` is True but numpy is not installed.
         """
         # Validate input
         if chunk_size < 8:
@@ -98,12 +76,6 @@ class VernamVeil(_Cypher):
             raise ValueError("padding_range values must be in ascending order.")
         if decoy_ratio < 0:
             raise ValueError("decoy_ratio must not be negative.")
-        if vectorise and not _HAS_NUMPY:
-            raise ValueError("NumPy is required for vectorised mode but is not installed.")
-        elif not vectorise and _HAS_NUMPY:
-            warnings.warn(
-                "vectorise is False, NumPy will not be used. Consider setting it to True for better performance."
-            )
 
         # Initialise instance variables
         self._fx = fx
@@ -113,7 +85,6 @@ class VernamVeil(_Cypher):
         self._decoy_ratio = decoy_ratio
         self._siv_seed_initialisation = siv_seed_initialisation
         self._auth_encrypt = auth_encrypt
-        self._vectorise = vectorise
 
     def __str__(self) -> str:
         """Return a string representation of the VernamVeil instance.
@@ -127,8 +98,7 @@ class VernamVeil(_Cypher):
             f"padding_range={self._padding_range}, "
             f"decoy_ratio={self._decoy_ratio}, "
             f"siv_seed_initialisation={self._siv_seed_initialisation}, "
-            f"auth_encrypt={self._auth_encrypt}, "
-            f"vectorise={self._vectorise})"
+            f"auth_encrypt={self._auth_encrypt}"
         )
 
     @classmethod
@@ -167,17 +137,6 @@ class VernamVeil(_Cypher):
         """
         return 64
 
-    @property
-    def _block_size(self) -> int:
-        """Return the block size of the VernamVeil class.
-
-        Given a fixed configuration, it is a constant value representing the size of the blocks used in the encryption.
-
-        Returns:
-            int: The block size in bytes.
-        """
-        return self._hmac_length if self._vectorise else 8
-
     def _hmac(
         self, key: bytes | bytearray | memoryview, msg_list: list[bytes | memoryview] | None = None
     ) -> bytes:
@@ -209,8 +168,6 @@ class VernamVeil(_Cypher):
 
         Determines the shuffled positions for real chunks based on a deterministic seed.
 
-        Uses `hash_numpy` for vectorised hashing if available.
-
         Args:
             seed (bytes): Seed for deterministic shuffling.
             real_count (int): Number of real chunks.
@@ -223,7 +180,7 @@ class VernamVeil(_Cypher):
         positions = list(range(total_count))
 
         hashes: Any
-        if self._vectorise:
+        if self._fx.vectorise:
             # Vectorised: generate all hashes at once
             i_arr = np.arange(1, total_count, dtype=np.uint64)
             hashes = fold_bytes_to_uint64(hash_numpy(i_arr, seed, "blake2b"))
@@ -247,10 +204,7 @@ class VernamVeil(_Cypher):
     def _generate_bytes(self, length: int, seed: bytes) -> memoryview:
         """Produce a byte stream of the given length using the key generator function.
 
-        In vectorised mode, uses numpy for efficient batch generation if available and supported by `fx`.
-
-        It samples _block_size bytes at a time from the generator function, which is expected to return a Python int
-        or an uint8 NumPy array.
+        It samples `fx.block_size` bytes at a time.
 
         Args:
             length (int): Number of bytes to generate.
@@ -259,10 +213,10 @@ class VernamVeil(_Cypher):
         Returns:
             memoryview: Generated byte stream.
         """
-        if self._vectorise:
+        if self._fx.vectorise:
             # Vectorised generation using numpy
             # Generate enough uint64s to cover the length
-            n_uint64 = math.ceil(length / self._block_size)
+            n_uint64 = math.ceil(length / self._fx.block_size)
             indices = np.arange(1, n_uint64 + 1, dtype=np.uint64)
             # Generate uint8 for bytes
             keystream = self._fx(indices, seed)
@@ -429,7 +383,7 @@ class VernamVeil(_Cypher):
         # Preallocate memory and avoid copying when slicing
         data_len = len(data)
         result = bytearray(data_len)
-        if self._vectorise:
+        if self._fx.vectorise:
             arr = np.frombuffer(data, dtype=np.uint8)
             # Create a numpy array on top of the bytearray to vectorise and still have access to original bytearray
             processed = np.frombuffer(result, dtype=np.uint8)
@@ -443,7 +397,7 @@ class VernamVeil(_Cypher):
             keystream = self._generate_bytes(chunk_len, seed)
 
             # XOR the chunk with the key
-            if self._vectorise:
+            if self._fx.vectorise:
                 np.bitwise_xor(arr[start:end], keystream, out=processed[start:end])
                 seed_data = (arr[start:end] if is_encode else processed[start:end]).data
             else:

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -15,20 +15,20 @@ from vernamveil._cypher import _Cypher
 from vernamveil._hash_utils import _UINT64_BOUND, fold_bytes_to_uint64, hash_numpy
 
 np: Any
-_IntOrArray: Any
-_IntOrBytes: Any
+_Integer: Any
+_Bytes: Any
 try:
     import numpy
     from numpy.typing import NDArray
 
     np = numpy
-    _IntOrArray = int | NDArray
-    _IntOrBytes = int | NDArray | bytes
+    _Integer = int | NDArray[np.uint64]
+    _Bytes = bytes | NDArray[np.uint8]
     _HAS_NUMPY = True
 except ImportError:
     np = None
-    _IntOrArray = int
-    _IntOrBytes = int | bytes
+    _Integer = int
+    _Bytes = bytes
     _HAS_NUMPY = False
 
 
@@ -46,7 +46,7 @@ class VernamVeil(_Cypher):
 
     def __init__(
         self,
-        fx: Callable[[_IntOrArray, bytes, int | None], _IntOrBytes],
+        fx: Callable[[_Integer, bytes, int | None], _Bytes],
         chunk_size: int = 32,
         delimiter_size: int = 8,
         padding_range: tuple[int, int] = (5, 15),
@@ -58,8 +58,8 @@ class VernamVeil(_Cypher):
         """Initialise the VernamVeil encryption cypher with configurable parameters.
 
         Args:
-            fx (Callable): Key stream generator accepting (int | np.ndarray, bytes, int | None) and returning an
-                int or np.ndarray or bytes. This function is critical for the encryption process and should be carefully
+            fx (Callable): Key stream generator accepting (int | np.ndarray[np.uint64], bytes, int | None) and returning an
+                bytes or np.ndarray[np.uint8]. This function is critical for the encryption process and should be carefully
                 designed to ensure cryptographic security.
             chunk_size (int): Size of message chunks. Defaults to 32.
             delimiter_size (int): The delimiter size in bytes used for separating chunks; must be


### PR DESCRIPTION
Fixes #9

Implements block-based keystream generation by updating the API of `fx` to return bytes.