### PR TITLE
Experimental SIMD support

### DIFF
--- a/nphash/_npblake2b.c
+++ b/nphash/_npblake2b.c
@@ -4,6 +4,37 @@
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 
+// #define __NO_SIMD__  // Uncomment to disable SIMD optimisations
+
+#if !defined(__NO_SIMD__)
+
+// SIMD intrinsics headers and alignment macro
+#if defined(__AVX512F__)
+#include <immintrin.h>
+#define NP_SIMD_AVX512 1
+#define NP_SIMD_BATCH 8
+#define NP_SIMD_ALIGN 64
+#elif defined(__AVX2__)
+#include <immintrin.h>
+#define NP_SIMD_AVX2 1
+#define NP_SIMD_BATCH 4
+#define NP_SIMD_ALIGN 32
+#elif defined(__SSE2__) || (defined(_MSC_VER) && (defined(_M_X64) || _M_IX86_FP >= 2))
+#include <emmintrin.h>
+#define NP_SIMD_SSE2 1
+#define NP_SIMD_BATCH 2
+#define NP_SIMD_ALIGN 16
+#endif
+
+// Alignment macro for SIMD types
+#if defined(_MSC_VER)
+#define ALIGNED(N) __declspec(align(N))
+#else
+#define ALIGNED(N) __attribute__((aligned(N)))
+#endif
+
+#endif
+
 #ifdef _OPENMP
 // Enable parallelisation with OpenMP for multi-core performance
 #include <omp.h>
@@ -11,6 +42,22 @@
 
 #define BLOCK_SIZE 8  // Each input element is an uint64 block
 #define HASH_SIZE 64  // BLAKE2b output size in bytes
+
+
+// Utility: HMAC BLAKE2b for a single block
+static inline void hmac_blake2b(const char* seed, int seedlen, const unsigned char* block, uint8_t* out) {
+    HMAC(EVP_blake2b512(), seed, seedlen, block, BLOCK_SIZE, out, NULL);
+}
+
+// Utility: Hash BLAKE2b for a single block
+static inline void hash_blake2b(const unsigned char* block, uint8_t* out) {
+    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+    int ok = (ctx != NULL);
+    ok &= EVP_DigestInit_ex(ctx, EVP_blake2b512(), NULL) == 1;
+    ok &= EVP_DigestUpdate(ctx, block, BLOCK_SIZE) == 1;
+    ok &= EVP_DigestFinal_ex(ctx, out, NULL) == 1;
+    EVP_MD_CTX_free(ctx);
+}
 
 // HMACs or hashes an array of uint64 elements with a seed using BLAKE2b, outputs 64-byte hashes
 // - If a seed is provided, HMAC is used for cryptographic safety.
@@ -21,35 +68,76 @@ void numpy_blake2b(const uint64_t* restrict arr, const size_t n, const char* res
     // When passing to hash/HMAC, use (const unsigned char *)&arr[i] and BLOCK_SIZE
     const unsigned char (*arr8)[BLOCK_SIZE] = (const unsigned char (*)[BLOCK_SIZE])arr;
     const int n_int = (int)n;
-    int i;
+    int i = 0;
 
     if (seed != NULL && seedlen > 0) {
-        const int seedlen_int = (int)seedlen;
-
-        // HMAC mode: Use HMAC with BLAKE2b (cryptographically safer)
+    #if defined(NP_SIMD_AVX512) || defined(NP_SIMD_AVX2) || defined(NP_SIMD_SSE2)
+        // SIMD path: batch process with AVX512, AVX2 or SSE2
+        const int batch = NP_SIMD_BATCH;
         #ifdef _OPENMP
         // Parallelise the loop with OpenMP to use multiple CPU cores
         #pragma omp parallel for schedule(static)
         #endif
-        for (i = 0; i < n_int; ++i) {
+        for (i = 0; i <= n_int - batch; i += batch) {
+            ALIGNED(NP_SIMD_ALIGN) unsigned char tmp[NP_SIMD_BATCH][BLOCK_SIZE];
+        #if NP_SIMD_AVX512
+            __m512i v = _mm512_loadu_si512((const void*)arr8[i]);
+            _mm512_store_si512((void*)tmp, v);
+        #elif NP_SIMD_AVX2
+            __m256i v = _mm256_loadu_si256((const __m256i*)arr8[i]);
+            _mm256_store_si256((__m256i*)tmp, v);
+        #elif NP_SIMD_SSE2
+            __m128i v = _mm_loadu_si128((const __m128i*)arr8[i]);
+            _mm_store_si128((__m128i*)tmp, v);
+        #endif
             // Write HMAC output directly to the output buffer
-            HMAC(EVP_blake2b512(), seed, seedlen_int, arr8[i], BLOCK_SIZE, &out[i * HASH_SIZE], NULL);
+            for (int j = 0; j < batch; ++j) {
+                hmac_blake2b(seed, (int)seedlen, tmp[j], &out[(i + j) * HASH_SIZE]);
+            }
+        }
+        // the scalar fallback and the non-SIMD branch are unified and follow the above ifdef
+    #endif
+        #ifdef _OPENMP
+        // Enable parallelisation with OpenMP for multi-core performance
+        #pragma omp parallel for schedule(static)
+        #endif
+        for (int k = i; k < n_int; ++k) {
+            hmac_blake2b(seed, (int)seedlen, arr8[k], &out[k * HASH_SIZE]);
         }
     } else {
-        // No-seed mode: Just hash the block
+        // Hash branch
+    #if defined(NP_SIMD_AVX512) || defined(NP_SIMD_AVX2) || defined(NP_SIMD_SSE2)
+        // SIMD path: batch process with AVX512, AVX2 or SSE2
+        const int batch = NP_SIMD_BATCH;
         #ifdef _OPENMP
         // Parallelise the loop with OpenMP to use multiple CPU cores
         #pragma omp parallel for schedule(static)
         #endif
-        for (i = 0; i < n_int; ++i) {
+        for (i = 0; i <= n_int - batch; i += batch) {
+            ALIGNED(NP_SIMD_ALIGN) unsigned char tmp[NP_SIMD_BATCH][BLOCK_SIZE];
+        #if NP_SIMD_AVX512
+            __m512i v = _mm512_loadu_si512((const void*)arr8[i]);
+            _mm512_store_si512((void*)tmp, v);
+        #elif NP_SIMD_AVX2
+            __m256i v = _mm256_loadu_si256((const __m256i*)arr8[i]);
+            _mm256_store_si256((__m256i*)tmp, v);
+        #elif NP_SIMD_SSE2
+            __m128i v = _mm_loadu_si128((const __m128i*)arr8[i]);
+            _mm_store_si128((__m128i*)tmp, v);
+        #endif
             // Create a new digest context for each hash computation
-            EVP_MD_CTX* ctx = EVP_MD_CTX_new();
-            // Compute BLAKE2b hash of the uint64 block by chaining all hash steps
-            int ok = (ctx != NULL);
-            ok &= EVP_DigestInit_ex(ctx, EVP_blake2b512(), NULL) == 1;
-            ok &= EVP_DigestUpdate(ctx, arr8[i], BLOCK_SIZE) == 1;
-            ok &= EVP_DigestFinal_ex(ctx, &out[i * HASH_SIZE], NULL) == 1;
-            EVP_MD_CTX_free(ctx);
+            for (int j = 0; j < batch; ++j) {
+                hash_blake2b(tmp[j], &out[(i + j) * HASH_SIZE]);
+            }
+        }
+        // the scalar fallback and the non-SIMD branch are unified and follow the above ifdef
+    #endif
+        #ifdef _OPENMP
+        // Enable parallelisation with OpenMP for multi-core performance
+        #pragma omp parallel for schedule(static)
+        #endif
+        for (int k = i; k < n_int; ++k) {
+            hash_blake2b(arr8[k], &out[k * HASH_SIZE]);
         }
     }
 }

--- a/nphash/_npsha256.c
+++ b/nphash/_npsha256.c
@@ -4,6 +4,37 @@
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
 
+// #define __NO_SIMD__  // Uncomment to disable SIMD optimisations
+
+#if !defined(__NO_SIMD__)
+
+// SIMD intrinsics headers and alignment macro
+#if defined(__AVX512F__)
+#include <immintrin.h>
+#define NP_SIMD_AVX512 1
+#define NP_SIMD_BATCH 8
+#define NP_SIMD_ALIGN 64
+#elif defined(__AVX2__)
+#include <immintrin.h>
+#define NP_SIMD_AVX2 1
+#define NP_SIMD_BATCH 4
+#define NP_SIMD_ALIGN 32
+#elif defined(__SSE2__) || (defined(_MSC_VER) && (defined(_M_X64) || _M_IX86_FP >= 2))
+#include <emmintrin.h>
+#define NP_SIMD_SSE2 1
+#define NP_SIMD_BATCH 2
+#define NP_SIMD_ALIGN 16
+#endif
+
+// Alignment macro for SIMD types
+#if defined(_MSC_VER)
+#define ALIGNED(N) __declspec(align(N))
+#else
+#define ALIGNED(N) __attribute__((aligned(N)))
+#endif
+
+#endif
+
 #ifdef _OPENMP
 // Enable parallelisation with OpenMP for multi-core performance
 #include <omp.h>
@@ -11,6 +42,22 @@
 
 #define BLOCK_SIZE 8  // Each input element is an uint64 block
 #define HASH_SIZE 32  // SHA256 output size in bytes
+
+
+// Utility: HMAC SHA256 for a single block
+static inline void hmac_sha256(const char* seed, int seedlen, const unsigned char* block, uint8_t* out) {
+    HMAC(EVP_sha256(), seed, seedlen, block, BLOCK_SIZE, out, NULL);
+}
+
+// Utility: Hash SHA256 for a single block
+static inline void hash_sha256(const unsigned char* block, uint8_t* out) {
+    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+    int ok = (ctx != NULL);
+    ok &= EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) == 1;
+    ok &= EVP_DigestUpdate(ctx, block, BLOCK_SIZE) == 1;
+    ok &= EVP_DigestFinal_ex(ctx, out, NULL) == 1;
+    EVP_MD_CTX_free(ctx);
+}
 
 // HMACs or hashes an array of uint64 elements with a seed using SHA256, outputs 32-byte hashes
 // - If a seed is provided, HMAC is used for cryptographic safety.
@@ -21,35 +68,76 @@ void numpy_sha256(const uint64_t* restrict arr, const size_t n, const char* rest
     // When passing to hash/HMAC, use (const unsigned char *)&arr[i] and BLOCK_SIZE
     const unsigned char (*arr8)[BLOCK_SIZE] = (const unsigned char (*)[BLOCK_SIZE])arr;
     const int n_int = (int)n;
-    int i;
+    int i = 0;
 
     if (seed != NULL && seedlen > 0) {
-        const int seedlen_int = (int)seedlen;
-
-        // HMAC mode: Use HMAC with SHA256 (cryptographically safer)
+    #if defined(NP_SIMD_AVX512) || defined(NP_SIMD_AVX2) || defined(NP_SIMD_SSE2)
+        // SIMD path: batch process with AVX512, AVX2 or SSE2
+        const int batch = NP_SIMD_BATCH;
         #ifdef _OPENMP
         // Parallelise the loop with OpenMP to use multiple CPU cores
         #pragma omp parallel for schedule(static)
         #endif
-        for (i = 0; i < n_int; ++i) {
+        for (i = 0; i <= n_int - batch; i += batch) {
+            ALIGNED(NP_SIMD_ALIGN) unsigned char tmp[NP_SIMD_BATCH][BLOCK_SIZE];
+        #if NP_SIMD_AVX512
+            __m512i v = _mm512_loadu_si512((const void*)arr8[i]);
+            _mm512_store_si512((void*)tmp, v);
+        #elif NP_SIMD_AVX2
+            __m256i v = _mm256_loadu_si256((const __m256i*)arr8[i]);
+            _mm256_store_si256((__m256i*)tmp, v);
+        #elif NP_SIMD_SSE2
+            __m128i v = _mm_loadu_si128((const __m128i*)arr8[i]);
+            _mm_store_si128((__m128i*)tmp, v);
+        #endif
             // Write HMAC output directly to the output buffer
-            HMAC(EVP_sha256(), seed, seedlen_int, arr8[i], BLOCK_SIZE, &out[i * HASH_SIZE], NULL);
+            for (int j = 0; j < batch; ++j) {
+                hmac_sha256(seed, (int)seedlen, tmp[j], &out[(i + j) * HASH_SIZE]);
+            }
+        }
+        // the scalar fallback and the non-SIMD branch are unified and follow the above ifdef
+    #endif
+        #ifdef _OPENMP
+        // Enable parallelisation with OpenMP for multi-core performance
+        #pragma omp parallel for schedule(static)
+        #endif
+        for (int k = i; k < n_int; ++k) {
+            hmac_sha256(seed, (int)seedlen, arr8[k], &out[k * HASH_SIZE]);
         }
     } else {
-        // No-seed mode: Just hash the block
+        // Hash branch
+    #if defined(NP_SIMD_AVX512) || defined(NP_SIMD_AVX2) || defined(NP_SIMD_SSE2)
+        // SIMD path: batch process with AVX512, AVX2 or SSE2
+        const int batch = NP_SIMD_BATCH;
         #ifdef _OPENMP
         // Parallelise the loop with OpenMP to use multiple CPU cores
         #pragma omp parallel for schedule(static)
         #endif
-        for (i = 0; i < n_int; ++i) {
+        for (i = 0; i <= n_int - batch; i += batch) {
+            ALIGNED(NP_SIMD_ALIGN) unsigned char tmp[NP_SIMD_BATCH][BLOCK_SIZE];
+        #if NP_SIMD_AVX512
+            __m512i v = _mm512_loadu_si512((const void*)arr8[i]);
+            _mm512_store_si512((void*)tmp, v);
+        #elif NP_SIMD_AVX2
+            __m256i v = _mm256_loadu_si256((const __m256i*)arr8[i]);
+            _mm256_store_si256((__m256i*)tmp, v);
+        #elif NP_SIMD_SSE2
+            __m128i v = _mm_loadu_si128((const __m128i*)arr8[i]);
+            _mm_store_si128((__m128i*)tmp, v);
+        #endif
             // Create a new digest context for each hash computation
-            EVP_MD_CTX* ctx = EVP_MD_CTX_new();
-            // Compute SHA256 hash of the uint64 block by chaining all hash steps
-            int ok = (ctx != NULL);
-            ok &= EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) == 1;
-            ok &= EVP_DigestUpdate(ctx, arr8[i], BLOCK_SIZE) == 1;
-            ok &= EVP_DigestFinal_ex(ctx, &out[i * HASH_SIZE], NULL) == 1;
-            EVP_MD_CTX_free(ctx);
+            for (int j = 0; j < batch; ++j) {
+                hash_sha256(tmp[j], &out[(i + j) * HASH_SIZE]);
+            }
+        }
+        // the scalar fallback and the non-SIMD branch are unified and follow the above ifdef
+    #endif
+        #ifdef _OPENMP
+        // Enable parallelisation with OpenMP for multi-core performance
+        #pragma omp parallel for schedule(static)
+        #endif
+        for (int k = i; k < n_int; ++k) {
+            hash_sha256(arr8[k], &out[k * HASH_SIZE]);
         }
     }
 }


### PR DESCRIPTION
This PR:

- Attempted to accelerate hashing by batching input blocks using SIMD intrinsics (AVX512, AVX2, SSE2) in the C extensions.
- The goal was to improve memory throughput by loading multiple blocks at once before passing them to OpenSSL's HMAC/hash routines.
- Result: A slowdown was observed. OpenSSL already uses highly optimized SIMD code internally for hashing, so external SIMD batching only affects memory movement, not the cryptographic computation and actually adds overhead.
- If OpenSSL ever supports true batch hashing/HMAC APIs, this batching and SIMD logic could serve as a useful starting point.

This PR documents the experiment and will be closed without merging.