### PR TITLE
Switch HMAC with faster Keyed hashing on the `fx`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set benchmark sizes
         id: benchvars
         run: |
-          echo "SIZES=5 25 75" >> $GITHUB_ENV
+          echo "SIZES=5 25 100" >> $GITHUB_ENV
 
       - name: Install system dependencies and build C modules
         run: |

--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@ pip install .
 
 Minimal Example:
 ```python
-import hmac
+import hashlib
 from vernamveil import FX, VernamVeil
 
 
 # Step 1: Define a custom key stream function; remember to store this securely
 def keystream_fn(i: int, seed: bytes) -> int:
     # Simple cryptographically safe fx; see below for a more complex example
-    return hmac.new(seed, i.to_bytes(8, "big"), digestmod="blake2b").digest()
+    hasher = hashlib.blake2b(seed)
+    hasher.update(i.to_bytes(8, "big"))
+    return hasher.digest()
 
 fx = FX(keystream_fn, block_size=64, vectorise=False)
 
@@ -167,23 +169,23 @@ When creating your own key stream function (`fx`), it is essential to follow bes
 - **Performance**: Complex or slow `fx` functions will slow down encryption and decryption. Test performance if speed is important for your use case.
 
 **Recommended approach:**  
-Apply a unique, high-entropy transformation to the input index using a function that incorporates constant but randomly sampled parameters to make each `fx` instance unpredictable. Then, combine the result with the secret seed using a cryptographically secure method such as HMAC. This ensures your keystream is both unpredictable and securely bound to your secret.
+Apply a unique, high-entropy transformation to the input index using a function that incorporates constant but randomly sampled parameters to make each `fx` instance unpredictable. Then, combine the result with the secret seed using a cryptographically secure keyed hash method. This ensures your keystream is both unpredictable and securely bound to your secret.
 
 **Always test your custom `fx`** with the provided `check_fx_sanity` utility before using it for encryption. Note that this method only performs very basic checks and cannot guarantee cryptographic security; it may catch common mistakes, but passing all checks does not mean your function is secure.
 
 Below we provide some example `fx` methods to illustrate these principles in practice:
 
-### 🧠 A more robust, HMAC-based scalar `fx` (not cryptographically standard)
+### 🧠 A more robust, Keyed Hash-based scalar `fx` (not cryptographically standard)
 
 ```python
-import hmac
+import hashlib
 from vernamveil import FX
 
 
 def keystream_fn(i: int, seed: bytes) -> int:
     # Implements a customisable fx function based on a 10-degree polynomial transformation of the index,
-    # followed by a cryptographically secure HMAC-Blake2b output.
-    # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the HMAC.
+    # followed by a cryptographically secure keyed hash (Blake2b) output.
+    # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the keyed hash.
     # The polynomial transformation adds uniqueness to each fx instance but does not contribute additional entropy.
     weights = [24242, 68652, 77629, 55585, 32284, 78741, 70249, 39611, 54080, 73198, 12426]
 
@@ -194,8 +196,10 @@ def keystream_fn(i: int, seed: bytes) -> int:
         result = (result + weight * current_pow) & 0xFFFFFFFFFFFFFFFF
         current_pow = (current_pow * i) & 0xFFFFFFFFFFFFFFFF
 
-    # Cryptographic HMAC using Blake2b
-    return hmac.new(seed, result.to_bytes(8, "big"), digestmod="blake2b").digest()
+    # Cryptographic keyed hash using Blake2b
+    hasher = hashlib.blake2b(seed)
+    hasher.update(i.to_bytes(8, "big"))
+    return hasher.digest()
 
 
 fx = FX(keystream_fn, block_size=64, vectorise=False)
@@ -210,8 +214,8 @@ from vernamveil import FX, hash_numpy
 
 def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
     # Implements a customisable fx function based on a 10-degree polynomial transformation of the index,
-    # followed by a cryptographically secure HMAC-Blake2b output.
-    # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the HMAC.
+    # followed by a cryptographically secure keyed hash (Blake2b) output.
+    # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the keyed hash.
     # The polynomial transformation adds uniqueness to each fx instance but does not contribute additional entropy.
     weights = np.array([24242, 68652, 77629, 55585, 32284, 78741, 70249, 39611, 54080, 73198, 12426], dtype=np.uint64)
 
@@ -222,14 +226,14 @@ def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
     # Weighted sum (polynomial evaluation)
     result = np.dot(powers, weights)
 
-    # Cryptographic HMAC using Blake2b
+    # Cryptographic keyed hash using Blake2b
     return hash_numpy(result, seed, "blake2b")  # uses C module if available, else NumPy fallback
 
 
 fx = FX(keystream_fn, block_size=64, vectorise=True)
 ```
 
-### 🛡️ A cryptographically strong HMAC-SHA256 `fx` (vectorised & C-accelerated)
+### 🛡️ A cryptographically strong Keyed Hash SHA256 `fx` (vectorised & C-accelerated)
 
 ```python
 import numpy as np
@@ -237,11 +241,11 @@ from vernamveil import FX, hash_numpy
 
 
 def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
-    # Implements a standard HMAC-based pseudorandom function (PRF) using sha256.
+    # Implements a standard keyed hash-based pseudorandom function (PRF) using sha256.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
-    # Security relies entirely on the secrecy of the seed and the cryptographic strength of HMAC.
+    # Security relies entirely on the secrecy of the seed and the cryptographic strength of the keyed hash.
 
-    # Cryptographic HMAC using sha256
+    # Cryptographic keyed hash using sha256
     return hash_numpy(i, seed, "sha256")  # uses C module if available, else NumPy fallback
 
 
@@ -255,8 +259,8 @@ fx = FX(keystream_fn, block_size=64, vectorise=True)
 VernamVeil includes helper tools to make working with key stream functions easier:
 
 - `check_fx_sanity`: Runs basic sanity checks on your custom `fx` to ensure it produces diverse and seed-sensitive outputs.
-- `generate_default_fx` (same as `generate_polynomial_fx`): Generates a random `fx` function that first transforms the index using a polynomial with random weights, then applies HMAC (Blake2b) for cryptographic output. Supports both scalar and vectorised (NumPy) modes.
-- `generate_hmac_fx`: Generates a deterministic `fx` function that applies HMAC (using a specified hash algorithm, e.g., BLAKE2b or SHA-256) directly to the index and seed. The seed is the only secret key but HMAC is a cryptographically strong and proven `fx`. Supports both scalar and vectorised (NumPy) modes.
+- `generate_default_fx` (same as `generate_polynomial_fx`): Generates a random `fx` function that first transforms the index using a polynomial with random weights, then applies keyed hashing (Blake2b) for cryptographic output. Supports both scalar and vectorised (NumPy) modes.
+- `generate_keyed_hash_fx`: Generates a deterministic `fx` function that applies a specified hash algorithm (e.g., BLAKE2b or SHA-256) directly to the index and seed. The seed is the only secret key but the keyed hash is a cryptographically strong and proven `fx`. Supports both scalar and vectorised (NumPy) modes.
 - `load_fx_from_file`: Loads a custom `fx` function from a Python file. This is useful for testing and validating your own implementations. This uses `importlib` internally to import the `fx`. **Never use this with files from untrusted sources, as it can run arbitrary code on your system.**
 
 These utilities help you prototype and validate your own key stream functions before using them in encryption.
@@ -379,7 +383,7 @@ See `vernamveil encode --help` and `vernamveil decode --help` for all available 
 
 - **Compact Implementation**: The core algorithm implementation is about 200 lines of code, excluding comments, documentation and empty lines.
 - **External Dependencies**: Built using only Python's standard library, with NumPy being optional for vectorisation.
-- **Optional C Module for Fast Hashing**: Includes an optional C module (`nphash`) built with [cffi](https://cffi.readthedocs.io/), enabling fast BLAKE2b and SHA-256 estimations for vectorised `fx` functions. See the [`nphash` README](nphash/README.md) for details.
+- **Optional C Module for Fast Hashing**: Includes an optional C module (`nphash`) built with [cffi](https://cffi.readthedocs.io/), enabling fast BLAKE2b and SHA-256 keyed hashing for vectorised `fx` functions. See the [`nphash` README](nphash/README.md) for details.
 - **Tested with**: Python 3.10 and NumPy 2.2.5.
 
 ### 🔧 Installation
@@ -395,7 +399,7 @@ pip install .[dev,numpy,cffi]
 
 ### ⚡ Fast Vectorised `fx` Functions
 
-If you want to use fast vectorised key stream functions, install with both `numpy` and `cffi` enabled. The included `nphash` C module provides high-performance BLAKE2b and SHA-256 implementations for NumPy arrays, which are automatically used by `generate_default_fx(vectorise=True)` when available. If not present, a slower pure NumPy fallback is used.
+If you want to use fast vectorised key stream functions, install with both `numpy` and `cffi` enabled. The included `nphash` C module provides high-performance BLAKE2b and SHA-256 keyed hash implementations for NumPy arrays, which are automatically used by `generate_default_fx(vectorise=True)` when available. If not present, a slower pure NumPy fallback is used.
 
 **To use the C extension you must build it from source.** For more details, see [`nphash/README.md`](nphash/README.md).
 
@@ -403,7 +407,7 @@ If you want to use fast vectorised key stream functions, install with both `nump
 
 ## 🚦 Benchmarks: VernamVeil vs AES-256-CBC
 
-VernamVeil prioritises educational value and cryptographic experimentation over raw speed. As expected, it is significantly slower (about 5.5x) than highly optimised, hardware-accelerated cyphers like AES-256-CBC. This is due to its Python implementation and focus on flexibility rather than production-grade speed or safety. The following benchmarks compare VernamVeil (using its fastest configuration: NumPy vectorisation, C extension enabled, and an fx using `generate_hmac_fx`) to OpenSSL's AES-256-CBC on the same Ubuntu Linux machine.
+VernamVeil prioritises educational value and cryptographic experimentation over raw speed. As expected, it is significantly slower (about 5.5x) than highly optimised, hardware-accelerated cyphers like AES-256-CBC. This is due to its Python implementation and focus on flexibility rather than production-grade speed or safety. The following benchmarks compare VernamVeil (using its fastest configuration: NumPy vectorisation, C extension enabled, and a fx using `generate_keyed_hash_fx`) to OpenSSL's AES-256-CBC on the same Ubuntu Linux machine.
 
 ### ‍💻 Benchmark Setup
 
@@ -418,17 +422,17 @@ openssl rand -hex 32 > key.hex
 openssl rand -hex 16 > iv.hex
 ```
 
-### 🐢 VernamVeil (Vectorised + C extension + HMAC `fx`)
+### 🐢 VernamVeil (Vectorised + C extension + Keyed Hash `fx`)
 
 **Encoding:**
 ```bash
-vernamveil encode --infile /tmp/original.bin --outfile /tmp/output.enc --fx-file hmac_fx.py --seed-file seed.bin --buffer-size 134217728 --chunk-size 1048576 --delimiter-size 64 --padding-range 100 200 --decoy-ratio 0.01 --verbosity info
+vernamveil encode --infile /tmp/original.bin --outfile /tmp/output.enc --fx-file keyed_hash_fx.py --seed-file seed.bin --buffer-size 134217728 --chunk-size 1048576 --delimiter-size 64 --padding-range 100 200 --decoy-ratio 0.01 --verbosity info
 ```
 _Time: 16.528s_
 
 **Decoding:**
 ```bash
-vernamveil decode --infile /tmp/output.enc --outfile /tmp/output.dec --fx-file hmac_fx.py --seed-file seed.bin --buffer-size 136349200 --chunk-size 1048576 --delimiter-size 64 --padding-range 100 200 --decoy-ratio 0.01 --verbosity info
+vernamveil decode --infile /tmp/output.enc --outfile /tmp/output.dec --fx-file keyed_hash_fx.py --seed-file seed.bin --buffer-size 136349200 --chunk-size 1048576 --delimiter-size 64 --padding-range 100 200 --decoy-ratio 0.01 --verbosity info
 ```
 _Time: 15.511s_
 

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ If you want to use fast vectorised key stream functions, install with both `nump
 
 ## 🚦 Benchmarks: VernamVeil vs AES-256-CBC
 
-VernamVeil prioritises educational value and cryptographic experimentation over raw speed. As expected, it is significantly slower (about 5.5x) than highly optimised, hardware-accelerated cyphers like AES-256-CBC. This is due to its Python implementation and focus on flexibility rather than production-grade speed or safety. The following benchmarks compare VernamVeil (using its fastest configuration: NumPy vectorisation, C extension enabled, and a fx using `generate_keyed_hash_fx`) to OpenSSL's AES-256-CBC on the same Ubuntu Linux machine.
+VernamVeil prioritises educational value and cryptographic experimentation over raw speed. As expected, it is about 3x slower than highly optimised, hardware-accelerated cyphers like AES-256-CBC. This is due to its Python implementation and focus on flexibility rather than production-grade speed or safety. The following benchmarks compare VernamVeil (using its fastest configuration: NumPy vectorisation, C extension enabled, and a fx using `generate_keyed_hash_fx`) to OpenSSL's AES-256-CBC on the same Ubuntu Linux machine.
 
 ### ‍💻 Benchmark Setup
 
@@ -428,13 +428,13 @@ openssl rand -hex 16 > iv.hex
 ```bash
 vernamveil encode --infile /tmp/original.bin --outfile /tmp/output.enc --fx-file keyed_hash_fx.py --seed-file seed.bin --buffer-size 134217728 --chunk-size 1048576 --delimiter-size 64 --padding-range 100 200 --decoy-ratio 0.01 --verbosity info
 ```
-_Time: 16.528s_
+_Time: 9.841s_
 
 **Decoding:**
 ```bash
 vernamveil decode --infile /tmp/output.enc --outfile /tmp/output.dec --fx-file keyed_hash_fx.py --seed-file seed.bin --buffer-size 136349200 --chunk-size 1048576 --delimiter-size 64 --padding-range 100 200 --decoy-ratio 0.01 --verbosity info
 ```
-_Time: 15.511s_
+_Time: 8.408s_
 
 ### 🐇 AES-256-CBC (OpenSSL)
 
@@ -454,7 +454,7 @@ _Time: 2.636s_
 
 | Algorithm    | Encode Time | Decode Time |
 |--------------|-------------|-------------|
-| VernamVeil   | 16.5 s      | 15.5 s      |
+| VernamVeil   | 9.8 s       | 8.4 s       |
 | AES-256-CBC  | 3.0 s       | 2.6 s       |
 
 ---

--- a/docs/fx_utils.rst
+++ b/docs/fx_utils.rst
@@ -14,6 +14,6 @@ Fx Utilities
 
    Alias for :func:`vernamveil.generate_polynomial_fx`.
 
-.. autofunction:: generate_hmac_fx
+.. autofunction:: generate_keyed_hash_fx
 .. autofunction:: generate_polynomial_fx
 .. autofunction:: load_fx_from_file

--- a/nphash/README.md
+++ b/nphash/README.md
@@ -1,6 +1,6 @@
 # Building the `nphash` C Library with `build.py`
 
-This project optionally uses a C extension called `nphash` to efficiently compute BLAKE2b and SHA-256 based hashes from Python. The Python method `hash_numpy` can be used in `fx` methods to quickly produce required HMACs in vectorised implementations.
+This project optionally uses a C extension called `nphash` to efficiently compute BLAKE2b and SHA-256 based hashes from Python. The Python method `hash_numpy` can be used in `fx` methods to quickly produce required Hashes in vectorised implementations.
 
 The C code is compiled and wrapped for Python using the [cffi](https://cffi.readthedocs.io/en/latest/) library.
 

--- a/nphash/README.md
+++ b/nphash/README.md
@@ -1,6 +1,6 @@
 # Building the `nphash` C Library with `build.py`
 
-This project optionally uses a C extension called `nphash` to efficiently compute BLAKE2b and SHA-256 based hashes from Python. The Python method `hash_numpy` can be used in `fx` methods to quickly produce required Hashes in vectorised implementations.
+This project optionally uses a C extension called `nphash` to efficiently compute BLAKE2b and SHA-256 based hashes from Python. The Python method `hash_numpy` can be used in `fx` methods to quickly produce required keyed hashing in vectorised implementations.
 
 The C code is compiled and wrapped for Python using the [cffi](https://cffi.readthedocs.io/en/latest/) library.
 

--- a/nphash/_npblake2b.c
+++ b/nphash/_npblake2b.c
@@ -1,8 +1,9 @@
+#include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
+
 #include <openssl/evp.h>
-#include <openssl/hmac.h>
 
 #ifdef _OPENMP
 // Enable parallelisation with OpenMP for multi-core performance
@@ -12,45 +13,37 @@
 #define BLOCK_SIZE 8  // Each input element is an uint64 block
 #define HASH_SIZE 64  // BLAKE2b output size in bytes
 
-// HMACs or hashes an array of uint64 elements with a seed using BLAKE2b, outputs 64-byte hashes
-// - If a seed is provided, HMAC is used for cryptographic safety.
-// - If no seed is provided, a plain hash is used (not recommended for security).
+// Hashes an array of uint64 elements with a seed using BLAKE2b, outputs 64-byte hashes
+// - If a seed is provided, the keyed mode is used by prepending it to the input
 // - Output is a 2D uint8 array of shape n x 64 (n rows, 64 columns)
 void numpy_blake2b(const uint64_t* restrict arr, const size_t n, const char* restrict seed, const size_t seedlen, uint8_t* restrict out) {
     // Input: native-endian uint64_t array; each element is hashed as an 8-byte block
-    // When passing to hash/HMAC, use (const unsigned char *)&arr[i] and BLOCK_SIZE
     const unsigned char (*arr8)[BLOCK_SIZE] = (const unsigned char (*)[BLOCK_SIZE])arr;
+    const bool seeded = seed != NULL && seedlen > 0;
+    const int seedlen_int = (int)seedlen;
     const int n_int = (int)n;
-    int i;
 
-    if (seed != NULL && seedlen > 0) {
-        const int seedlen_int = (int)seedlen;
+    #ifdef _OPENMP
+    // Parallelise the loop with OpenMP to use multiple CPU cores
+    #pragma omp parallel for schedule(static)
+    #endif
+    for (int i = 0; i < n_int; ++i) {
+        // Create a new digest context for each hash computation; ensure thread safety
+        EVP_MD_CTX* ctx = EVP_MD_CTX_new();
 
-        // HMAC mode: Use HMAC with BLAKE2b (cryptographically safer)
-        #ifdef _OPENMP
-        // Parallelise the loop with OpenMP to use multiple CPU cores
-        #pragma omp parallel for schedule(static)
-        #endif
-        for (i = 0; i < n_int; ++i) {
-            // Write HMAC output directly to the output buffer
-            HMAC(EVP_blake2b512(), seed, seedlen_int, arr8[i], BLOCK_SIZE, &out[i * HASH_SIZE], NULL);
+        // Compute BLAKE2b hash of the uint64 block by chaining all hash steps
+        bool ok = (ctx != NULL) && (EVP_DigestInit_ex(ctx, EVP_blake2b512(), NULL) == 1);
+        if (seeded) {
+            // If a seed is provided, add it first
+            ok &= EVP_DigestUpdate(ctx, seed, seedlen_int) == 1;
         }
-    } else {
-        // No-seed mode: Just hash the block
-        #ifdef _OPENMP
-        // Parallelise the loop with OpenMP to use multiple CPU cores
-        #pragma omp parallel for schedule(static)
-        #endif
-        for (i = 0; i < n_int; ++i) {
-            // Create a new digest context for each hash computation
-            EVP_MD_CTX* ctx = EVP_MD_CTX_new();
-            // Compute BLAKE2b hash of the uint64 block by chaining all hash steps
-            if (ctx != NULL
-                && EVP_DigestInit_ex(ctx, EVP_blake2b512(), NULL) == 1
-                && EVP_DigestUpdate(ctx, arr8[i], BLOCK_SIZE) == 1) {
-                EVP_DigestFinal_ex(ctx, &out[i * HASH_SIZE], NULL);
-            }
-            EVP_MD_CTX_free(ctx);
+        ok &= EVP_DigestUpdate(ctx, arr8[i], BLOCK_SIZE) == 1;
+        if (ok) {
+            // Finalize the hash and write it to the output buffer
+            EVP_DigestFinal_ex(ctx, &out[i * HASH_SIZE], NULL);
         }
+
+        // Free the context to avoid memory leaks
+        EVP_MD_CTX_free(ctx);
     }
 }

--- a/nphash/_npblake2b.c
+++ b/nphash/_npblake2b.c
@@ -22,12 +22,13 @@ void numpy_blake2b(const uint64_t* restrict arr, const size_t n, const char* res
     const bool seeded = seed != NULL && seedlen > 0;
     const int seedlen_int = (int)seedlen;
     const int n_int = (int)n;
+    int i;
 
     #ifdef _OPENMP
     // Parallelise the loop with OpenMP to use multiple CPU cores
     #pragma omp parallel for schedule(static)
     #endif
-    for (int i = 0; i < n_int; ++i) {
+    for (i = 0; i < n_int; ++i) {
         // Create a new digest context for each hash computation; ensure thread safety
         EVP_MD_CTX* ctx = EVP_MD_CTX_new();
 

--- a/nphash/_npsha256.c
+++ b/nphash/_npsha256.c
@@ -1,8 +1,9 @@
+#include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
 #include <stdlib.h>
-#include <openssl/sha.h>
-#include <openssl/hmac.h>
+#include <string.h>
+
+#include <openssl/evp.h>
 
 #ifdef _OPENMP
 // Enable parallelisation with OpenMP for multi-core performance
@@ -12,45 +13,37 @@
 #define BLOCK_SIZE 8  // Each input element is an uint64 block
 #define HASH_SIZE 32  // SHA256 output size in bytes
 
-// HMACs or hashes an array of uint64 elements with a seed using SHA256, outputs 32-byte hashes
-// - If a seed is provided, HMAC is used for cryptographic safety.
-// - If no seed is provided, a plain hash is used (not recommended for security).
+// Hashes an array of uint64 elements with a seed using SHA256, outputs 32-byte hashes
+// - If a seed is provided, the keyed mode is used by prepending it to the input
 // - Output is a 2D uint8 array of shape n x 32 (n rows, 32 columns)
 void numpy_sha256(const uint64_t* restrict arr, const size_t n, const char* restrict seed, const size_t seedlen, uint8_t* restrict out) {
     // Input: native-endian uint64_t array; each element is hashed as an 8-byte block
-    // When passing to hash/HMAC, use (const unsigned char *)&arr[i] and BLOCK_SIZE
     const unsigned char (*arr8)[BLOCK_SIZE] = (const unsigned char (*)[BLOCK_SIZE])arr;
+    const bool seeded = seed != NULL && seedlen > 0;
+    const int seedlen_int = (int)seedlen;
     const int n_int = (int)n;
-    int i;
 
-    if (seed != NULL && seedlen > 0) {
-        const int seedlen_int = (int)seedlen;
+    #ifdef _OPENMP
+    // Parallelise the loop with OpenMP to use multiple CPU cores
+    #pragma omp parallel for schedule(static)
+    #endif
+    for (int i = 0; i < n_int; ++i) {
+        // Create a new digest context for each hash computation; ensure thread safety
+        EVP_MD_CTX* ctx = EVP_MD_CTX_new();
 
-        // HMAC mode: Use HMAC with SHA256 (cryptographically safer)
-        #ifdef _OPENMP
-        // Parallelise the loop with OpenMP to use multiple CPU cores
-        #pragma omp parallel for schedule(static)
-        #endif
-        for (i = 0; i < n_int; ++i) {
-            // Write HMAC output directly to the output buffer
-            HMAC(EVP_sha256(), seed, seedlen_int, arr8[i], BLOCK_SIZE, &out[i * HASH_SIZE], NULL);
+        // Compute SHA256 hash of the uint64 block by chaining all hash steps
+        bool ok = (ctx != NULL) && (EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) == 1);
+        if (seeded) {
+            // If a seed is provided, add it first
+            ok &= EVP_DigestUpdate(ctx, seed, seedlen_int) == 1;
         }
-    } else {
-        // No-seed mode: Just hash the block
-        #ifdef _OPENMP
-        // Parallelise the loop with OpenMP to use multiple CPU cores
-        #pragma omp parallel for schedule(static)
-        #endif
-        for (i = 0; i < n_int; ++i) {
-            // Create a new digest context for each hash computation
-            EVP_MD_CTX* ctx = EVP_MD_CTX_new();
-            // Compute SHA256 hash of the uint64 block by chaining all hash steps
-            if (ctx != NULL
-                && EVP_DigestInit_ex(ctx, EVP_sha256(), NULL) == 1
-                && EVP_DigestUpdate(ctx, arr8[i], BLOCK_SIZE) == 1) {
-                EVP_DigestFinal_ex(ctx, &out[i * HASH_SIZE], NULL);
-            }
-            EVP_MD_CTX_free(ctx);
+        ok &= EVP_DigestUpdate(ctx, arr8[i], BLOCK_SIZE) == 1;
+        if (ok) {
+            // Finalize the hash and write it to the output buffer
+            EVP_DigestFinal_ex(ctx, &out[i * HASH_SIZE], NULL);
         }
+
+        // Free the context to avoid memory leaks
+        EVP_MD_CTX_free(ctx);
     }
 }

--- a/nphash/_npsha256.c
+++ b/nphash/_npsha256.c
@@ -22,12 +22,13 @@ void numpy_sha256(const uint64_t* restrict arr, const size_t n, const char* rest
     const bool seeded = seed != NULL && seedlen > 0;
     const int seedlen_int = (int)seedlen;
     const int n_int = (int)n;
+    int i;
 
     #ifdef _OPENMP
     // Parallelise the loop with OpenMP to use multiple CPU cores
     #pragma omp parallel for schedule(static)
     #endif
-    for (int i = 0; i < n_int; ++i) {
+    for (i = 0; i < n_int; ++i) {
         // Create a new digest context for each hash computation; ensure thread safety
         EVP_MD_CTX* ctx = EVP_MD_CTX_new();
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,11 +66,13 @@ def keystream_fn(i, seed):
 fx = FX(keystream_fn, block_size=8, vectorise=False)
 """
         self.fx_strong_code = """
-import hmac
+import hashlib
 from vernamveil import FX
 
 def keystream_fn(i, seed):
-    return hmac.new(seed, i.to_bytes(8, "big"), digestmod="blake2b").digest()
+    hasher = hashlib.blake2b(seed)
+    hasher.update(i.to_bytes(8, "big"))
+    return hasher.digest()
 
 fx = FX(keystream_fn, block_size=64, vectorise=False)
 """

--- a/tests/test_hash_utils.py
+++ b/tests/test_hash_utils.py
@@ -1,5 +1,4 @@
 import hashlib
-import hmac
 import secrets
 import unittest
 from unittest.mock import patch
@@ -52,9 +51,9 @@ class TestHashUtils(unittest.TestCase):
                             method = self._get_hash_method_for_test(hash_name)
 
                             def get_digest(j):
-                                digest = hmac.new(
-                                    seed, i_bytes[j : j + 8], digestmod=method
-                                ).digest()
+                                hasher = method(seed)
+                                hasher.update(i_bytes[j : j + 8])
+                                digest = hasher.digest()
                                 if fold_type == "full":
                                     return int.from_bytes(digest, "big") % 2**64
                                 else:  # "view"

--- a/vernamveil/__init__.py
+++ b/vernamveil/__init__.py
@@ -7,7 +7,7 @@ from vernamveil._fx_utils import (
     FX,
     check_fx_sanity,
     generate_default_fx,
-    generate_hmac_fx,
+    generate_keyed_hash_fx,
     generate_polynomial_fx,
     load_fx_from_file,
 )
@@ -29,7 +29,7 @@ __all__ = [
     "fold_bytes_to_uint64",
     "forge_plausible_fx",
     "generate_default_fx",
-    "generate_hmac_fx",
+    "generate_keyed_hash_fx",
     "generate_polynomial_fx",
     "hash_numpy",
     "load_fx_from_file",

--- a/vernamveil/_cypher.py
+++ b/vernamveil/_cypher.py
@@ -44,17 +44,15 @@ class _Cypher(ABC):
 
     @abstractmethod
     def _hmac(
-        self, key: bytes | bytearray | memoryview, msg_list: list[bytes | memoryview] | None = None
+        self, key: bytes | bytearray | memoryview, msg_list: list[bytes | memoryview]
     ) -> bytes:
-        """Generate a hash-based message authentication code (HMAC) using the Blake2b algorithm.
+        """Generate a hash-based message authentication code (HMAC).
 
-        If `msg_list` is provided, each element is sequentially fed into the HMAC as message data.
-        If `msg_list` is `None`, only the key is hashed.
+        Each element in `msg_list` is sequentially fed into the HMAC as message data.
 
         Args:
-            key (bytes or bytearray or memoryview): The key for HMAC or Hash.
-            msg_list (list of bytes or memoryview, optional): List of message parts to hash with the key.
-                If None, only the key is hashed.
+            key (bytes or bytearray or memoryview): The key for HMAC.
+            msg_list (list of bytes or memoryview): List of message parts to hash with the key.
 
         Returns:
             bytes: The resulting hash digest.

--- a/vernamveil/_fx_utils.py
+++ b/vernamveil/_fx_utils.py
@@ -100,14 +100,14 @@ def generate_keyed_hash_fx(
     hash_name: Literal["blake2b", "sha256"] = "blake2b",
     vectorise: bool = False,
 ) -> FX:
-    """Generate a standard Hash-based pseudorandom function (PRF) using Blake2b or SHA256.
+    """Generate a standard keyed hash-based pseudorandom function (PRF) using Blake2b or SHA256.
 
     Args:
         hash_name (Literal["blake2b", "sha256"]): Hash function to use ("blake2b" or "sha256"). Defaults to "blake2b".
         vectorise (bool): If True, uses numpy arrays as input for vectorised operations. Defaults to False.
 
     Returns:
-        FX: A callable that returns pseudo-random bytes from Hash-based function.
+        FX: A callable that returns pseudo-random bytes from keyed hash-based function.
 
     Raises:
         ValueError: If `hash_name` is not "blake2b" or "sha256".
@@ -121,7 +121,7 @@ def generate_keyed_hash_fx(
     if not isinstance(vectorise, bool):
         raise TypeError("vectorise must be a boolean.")
 
-    # Dynamically generate the function code for scalar or vectorised Hash-based PRF
+    # Dynamically generate the function code for scalar or vectorised keyed hash-based PRF
     if vectorise:
         function_code = f"""
 import numpy as np
@@ -129,11 +129,11 @@ from vernamveil import FX, hash_numpy
 
 
 def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
-    # Implements a standard Hash-based pseudorandom function (PRF) using {hash_name}.
+    # Implements a standard keyed hash-based pseudorandom function (PRF) using {hash_name}.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
-    # Security relies entirely on the secrecy of the seed and the cryptographic strength of Hash.
+    # Security relies entirely on the secrecy of the seed and the cryptographic strength of the keyed hash.
 
-    # Cryptographic Hash using {hash_name}
+    # Cryptographic keyed hash using {hash_name}
     return hash_numpy(i, seed, "{hash_name}")  # uses C module if available, else NumPy fallback
 """
     else:
@@ -143,11 +143,11 @@ from vernamveil import FX
 
 
 def keystream_fn(i: int, seed: bytes) -> bytes:
-    # Implements a standard Hash-based pseudorandom function (PRF) using {hash_name}.
+    # Implements a standard keyed hash-based pseudorandom function (PRF) using {hash_name}.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
-    # Security relies entirely on the secrecy of the seed and the cryptographic strength of Hash.
+    # Security relies entirely on the secrecy of the seed and the cryptographic strength of the keyed hash.
 
-    # Cryptographic Hash using {hash_name}
+    # Cryptographic keyed hash using {hash_name}
     hasher = hashlib.new(hash_name, seed)
     hasher.update(i.to_bytes(8, "big"))
     return hasher.digest()
@@ -226,8 +226,8 @@ def make_keystream_fn():
 
     def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
         # Implements a customisable fx function based on a {degree}-degree polynomial transformation of the index,
-        # followed by a cryptographically secure Blake2b output.
-        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the Hash.
+        # followed by a cryptographically secure keyed hash (Blake2b) output.
+        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the keyed hash.
         # The polynomial transformation adds uniqueness to each fx instance but does not contribute additional entropy.
 
         # Transform index i using a polynomial function to introduce uniqueness on fx
@@ -236,7 +236,7 @@ def make_keystream_fn():
         # Weighted sum (polynomial evaluation)
         result = np.dot(powers, weights)
 
-        # Cryptographic Hash using Blake2b
+        # Cryptographic keyed hash using Blake2b
         return hash_numpy(result, seed, "blake2b")  # uses C module if available, else NumPy fallback
 
     return keystream_fn
@@ -253,8 +253,8 @@ def make_keystream_fn():
 
     def keystream_fn(i: int, seed: bytes) -> bytes:
         # Implements a customisable fx function based on a {degree}-degree polynomial transformation of the index,
-        # followed by a cryptographically secure Blake2b output.
-        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the Hash.
+        # followed by a cryptographically secure keyed hash (Blake2b) output.
+        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the keyed hash.
         # The polynomial transformation adds uniqueness to each fx instance but does not contribute additional entropy.
 
         # Transform index i using a polynomial function to introduce uniqueness on fx
@@ -264,7 +264,7 @@ def make_keystream_fn():
             result = (result + weight * current_pow) & 0xFFFFFFFFFFFFFFFF
             current_pow = (current_pow * i) & 0xFFFFFFFFFFFFFFFF
 
-        # Cryptographic Hash using Blake2b
+        # Cryptographic keyed hash using Blake2b
         hasher = hashlib.blake2b(seed)
         hasher.update(i.to_bytes(8, "big"))
         return hasher.digest()

--- a/vernamveil/_fx_utils.py
+++ b/vernamveil/_fx_utils.py
@@ -148,7 +148,7 @@ def keystream_fn(i: int, seed: bytes) -> bytes:
     # Security relies entirely on the secrecy of the seed and the cryptographic strength of the keyed hash.
 
     # Cryptographic keyed hash using {hash_name}
-    hasher = hashlib.new(hash_name, seed)
+    hasher = hashlib.new(hash_name, key=seed)
     hasher.update(i.to_bytes(8, "big"))
     return hasher.digest()
 """

--- a/vernamveil/_fx_utils.py
+++ b/vernamveil/_fx_utils.py
@@ -19,7 +19,7 @@ __all__ = [
     "FX",
     "check_fx_sanity",
     "generate_default_fx",
-    "generate_hmac_fx",
+    "generate_keyed_hash_fx",
     "generate_polynomial_fx",
     "load_fx_from_file",
 ]
@@ -96,18 +96,18 @@ class FX:
         return self.keystream_fn(i, seed)
 
 
-def generate_hmac_fx(
+def generate_keyed_hash_fx(
     hash_name: Literal["blake2b", "sha256"] = "blake2b",
     vectorise: bool = False,
 ) -> FX:
-    """Generate a standard HMAC-based pseudorandom function (PRF) using Blake2b or SHA256.
+    """Generate a standard Hash-based pseudorandom function (PRF) using Blake2b or SHA256.
 
     Args:
         hash_name (Literal["blake2b", "sha256"]): Hash function to use ("blake2b" or "sha256"). Defaults to "blake2b".
         vectorise (bool): If True, uses numpy arrays as input for vectorised operations. Defaults to False.
 
     Returns:
-        FX: A callable that returns pseudo-random bytes from HMAC-based function.
+        FX: A callable that returns pseudo-random bytes from Hash-based function.
 
     Raises:
         ValueError: If `hash_name` is not "blake2b" or "sha256".
@@ -121,7 +121,7 @@ def generate_hmac_fx(
     if not isinstance(vectorise, bool):
         raise TypeError("vectorise must be a boolean.")
 
-    # Dynamically generate the function code for scalar or vectorised HMAC-based PRF
+    # Dynamically generate the function code for scalar or vectorised Hash-based PRF
     if vectorise:
         function_code = f"""
 import numpy as np
@@ -129,26 +129,28 @@ from vernamveil import FX, hash_numpy
 
 
 def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
-    # Implements a standard HMAC-based pseudorandom function (PRF) using {hash_name}.
+    # Implements a standard Hash-based pseudorandom function (PRF) using {hash_name}.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
-    # Security relies entirely on the secrecy of the seed and the cryptographic strength of HMAC.
+    # Security relies entirely on the secrecy of the seed and the cryptographic strength of Hash.
 
-    # Cryptographic HMAC using {hash_name}
+    # Cryptographic Hash using {hash_name}
     return hash_numpy(i, seed, "{hash_name}")  # uses C module if available, else NumPy fallback
 """
     else:
         function_code = f"""
-import hmac
+import hashlib
 from vernamveil import FX
 
 
 def keystream_fn(i: int, seed: bytes) -> bytes:
-    # Implements a standard HMAC-based pseudorandom function (PRF) using {hash_name}.
+    # Implements a standard Hash-based pseudorandom function (PRF) using {hash_name}.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
-    # Security relies entirely on the secrecy of the seed and the cryptographic strength of HMAC.
+    # Security relies entirely on the secrecy of the seed and the cryptographic strength of Hash.
 
-    # Cryptographic HMAC using {hash_name}
-    return hmac.new(seed, i.to_bytes(8, "big"), digestmod="{hash_name}").digest()
+    # Cryptographic Hash using {hash_name}
+    hasher = hashlib.new(hash_name, seed)
+    hasher.update(i.to_bytes(8, "big"))
+    return hasher.digest()
 """
 
     function_code += f"""
@@ -176,7 +178,7 @@ def generate_polynomial_fx(
 ) -> FX:
     """Generate a random polynomial-based secret function to act as a deterministic key stream generator.
 
-    The transformed input index is passed to a cryptographic hash function (HMAC).
+    The transformed input index is passed to a cryptographic hash function.
 
     Args:
         degree (int): Degree of the polynomial. Defaults to 10.
@@ -224,8 +226,8 @@ def make_keystream_fn():
 
     def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
         # Implements a customisable fx function based on a {degree}-degree polynomial transformation of the index,
-        # followed by a cryptographically secure HMAC-Blake2b output.
-        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the HMAC.
+        # followed by a cryptographically secure Blake2b output.
+        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the Hash.
         # The polynomial transformation adds uniqueness to each fx instance but does not contribute additional entropy.
 
         # Transform index i using a polynomial function to introduce uniqueness on fx
@@ -234,14 +236,14 @@ def make_keystream_fn():
         # Weighted sum (polynomial evaluation)
         result = np.dot(powers, weights)
 
-        # Cryptographic HMAC using Blake2b
+        # Cryptographic Hash using Blake2b
         return hash_numpy(result, seed, "blake2b")  # uses C module if available, else NumPy fallback
 
     return keystream_fn
 """
     else:
         function_code = f"""
-import hmac
+import hashlib
 from vernamveil import FX
 
 
@@ -251,8 +253,8 @@ def make_keystream_fn():
 
     def keystream_fn(i: int, seed: bytes) -> bytes:
         # Implements a customisable fx function based on a {degree}-degree polynomial transformation of the index,
-        # followed by a cryptographically secure HMAC-Blake2b output.
-        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the HMAC.
+        # followed by a cryptographically secure Blake2b output.
+        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the Hash.
         # The polynomial transformation adds uniqueness to each fx instance but does not contribute additional entropy.
 
         # Transform index i using a polynomial function to introduce uniqueness on fx
@@ -262,8 +264,10 @@ def make_keystream_fn():
             result = (result + weight * current_pow) & 0xFFFFFFFFFFFFFFFF
             current_pow = (current_pow * i) & 0xFFFFFFFFFFFFFFFF
 
-        # Cryptographic HMAC using Blake2b
-        return hmac.new(seed, result.to_bytes(8, "big"), digestmod="blake2b").digest()
+        # Cryptographic Hash using Blake2b
+        hasher = hashlib.blake2b(seed)
+        hasher.update(i.to_bytes(8, "big"))
+        return hasher.digest()
 
     return keystream_fn
 """

--- a/vernamveil/_hash_utils.py
+++ b/vernamveil/_hash_utils.py
@@ -119,7 +119,7 @@ def hash_numpy(
             hasher = method()
             if seed is not None:
                 hasher.update(seed)
-            hasher.update(i_bytes.data[j: j + 8])
+            hasher.update(i_bytes.data[j : j + 8])
             out[idx, :] = np.frombuffer(hasher.digest(), dtype=np.uint8)
 
     return out

--- a/vernamveil/_hash_utils.py
+++ b/vernamveil/_hash_utils.py
@@ -64,7 +64,7 @@ def hash_numpy(
     seed: bytes | None = None,
     hash_name: Literal["blake2b", "sha256"] = "blake2b",
 ) -> "np.ndarray[tuple[int, int], np.dtype[np.uint8]]":
-    """Compute a 2D uint8 NumPy array by hashing each index with an optional seed using a hashing algorithm.
+    """Compute a 2D NumPy array of uint8 by applying a hash function to each index, optionally using a seed as a key.
 
     If no seed is provided, the index is hashed directly.
 

--- a/vernamveil/_hash_utils.py
+++ b/vernamveil/_hash_utils.py
@@ -4,7 +4,6 @@ This module provides fast, optionally C-accelerated hashing functions for use in
 """
 
 import hashlib
-import hmac
 from typing import Literal
 
 try:
@@ -65,17 +64,17 @@ def hash_numpy(
     seed: bytes | None = None,
     hash_name: Literal["blake2b", "sha256"] = "blake2b",
 ) -> "np.ndarray[tuple[int, int], np.dtype[np.uint8]]":
-    """Compute a 2D uint8 NumPy array by HMAC-ing or hashing each index with a seed using a hashing algorithm.
+    """Compute a 2D uint8 NumPy array by hashing each index with an optional seed using a hashing algorithm.
 
     If no seed is provided, the index is hashed directly.
 
     This function optionally uses cffi to call a custom C library, which wraps an optimised C implementation
-    (with OpenMP and OpenSSL) for efficient, parallelised HMAC hashing from Python. If the C module isn't available
+    (with OpenMP and OpenSSL) for efficient, parallelised hashing from Python. If the C module isn't available
     a NumPy fallback is used.
 
     Args:
         i (np.ndarray[tuple[int], np.dtype[np.uint64]]): NumPy array of indices (dtype should be unsigned 64-bit integer).
-        seed (bytes, optional): The seed bytes used as the HMAC key. If None, hashes only the index.
+        seed (bytes, optional): The seed bytes are prepended to the index. If None, hashes only the index.
         hash_name (Literal["blake2b", "sha256"]): Hash algorithm to use. Defaults to "blake2b".
 
     Returns:
@@ -117,10 +116,10 @@ def hash_numpy(
     else:
         i_bytes = i.view(np.uint8)
         for idx, j in enumerate(range(0, len(i_bytes), 8)):
+            hasher = method()
             if seed is not None:
-                digest = hmac.new(seed, i_bytes.data[j : j + 8], digestmod=method).digest()
-            else:
-                digest = method(i_bytes.data[j : j + 8]).digest()
-            out[idx, :] = np.frombuffer(digest, dtype=np.uint8)
+                hasher.update(seed)
+            hasher.update(i_bytes.data[j: j + 8])
+            out[idx, :] = np.frombuffer(hasher.digest(), dtype=np.uint8)
 
     return out

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -3,7 +3,6 @@
 Defines the main encryption class and core cryptographic operations.
 """
 
-import hashlib
 import hmac
 import math
 import secrets

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -127,28 +127,23 @@ class VernamVeil(_Cypher):
         return secrets.token_bytes(num_bytes)
 
     def _hmac(
-        self, key: bytes | bytearray | memoryview, msg_list: list[bytes | memoryview] | None = None
+        self, key: bytes | bytearray | memoryview, msg_list: list[bytes | memoryview]
     ) -> bytes:
-        """Generate a hash-based message authentication code (HMAC) using the Blake2b algorithm.
+        """Generate a hash-based message authentication code (HMAC).
 
-        If `msg_list` is provided, each element is sequentially fed into the HMAC as message data.
-        If `msg_list` is `None`, only the key is hashed.
+        Each element in `msg_list` is sequentially fed into the HMAC as message data.
 
         Args:
-            key (bytes or bytearray or memoryview): The key for HMAC or Hash.
-            msg_list (list of bytes or memoryview, optional): List of message parts to hash with the key.
-                If None, only the key is hashed.
+            key (bytes or bytearray or memoryview): The key for HMAC.
+            msg_list (list of bytes or memoryview): List of message parts to hash with the key.
 
         Returns:
             bytes: The resulting hash digest.
         """
-        if msg_list:
-            hm = hmac.new(key, msg_list.pop(0), digestmod="blake2b")
-            for m in msg_list:
-                hm.update(m)
-            return hm.digest()
-        else:
-            return hashlib.blake2b(key).digest()
+        hm = hmac.new(key, msg_list[0], digestmod="blake2b")
+        for i in range(1, len(msg_list)):
+            hm.update(msg_list[i])
+        return hm.digest()
 
     def _determine_shuffled_indices(
         self, seed: bytes, real_count: int, total_count: int


### PR DESCRIPTION
Why we are switching HMAC for keyed hashing:
- The use-case requires a cryptographically strong keyed hash for keystream generation, not specifically HMAC.
- Modern keyed hashes (e.g. BLAKE2b with a secret seed) provide strong security guarantees and are suitable for this construction.
- HMAC is designed to address weaknesses in legacy hash functions, but with secure primitives and proper key handling, direct keyed hashing is sufficient for this application.
- Keyed hashes enable faster, vectorised implementations (e.g. via C modules), improving performance without compromising security for the intended use.
- The protocol does not depend on HMAC-specific properties (such as resistance to length extension in legacy hashes), so keyed hashing is appropriate and meets all requirements.

Switching to Keyed Hashing reduces the execution times by 40%, so it's worth the tradeoff.