### PR TITLE
Revert to HMAC based SHA256

### DIFF
--- a/docs/fx_utils.rst
+++ b/docs/fx_utils.rst
@@ -14,6 +14,6 @@ Fx Utilities
 
    Alias for :func:`vernamveil.generate_polynomial_fx`.
 
-.. autofunction:: generate_keyed_hash_fx
+.. autofunction:: generate_hash_prf_fx
 .. autofunction:: generate_polynomial_fx
 .. autofunction:: load_fx_from_file

--- a/nphash/README.md
+++ b/nphash/README.md
@@ -1,6 +1,6 @@
 # Building the `nphash` C Library with `build.py`
 
-This project optionally uses a C extension called `nphash` to efficiently compute BLAKE2b and SHA-256 based hashes from Python. The Python method `hash_numpy` can be used in `fx` methods to quickly produce required keyed hashing in vectorised implementations.
+This project optionally uses a C extension called `nphash` to efficiently compute BLAKE2b and SHA-256 based hashes from Python. The Python method `hash_numpy` can be used in `fx` methods to quickly produce required hashing in vectorised implementations.
 
 The C code is compiled and wrapped for Python using the [cffi](https://cffi.readthedocs.io/en/latest/) library.
 

--- a/tests/test_hash_utils.py
+++ b/tests/test_hash_utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import hmac
 import secrets
 import unittest
 from unittest.mock import patch
@@ -51,9 +52,14 @@ class TestHashUtils(unittest.TestCase):
                             method = self._get_hash_method_for_test(hash_name)
 
                             def get_digest(j):
-                                hasher = method(seed)
-                                hasher.update(i_bytes[j : j + 8])
-                                digest = hasher.digest()
+                                if hash_name == "blake2b":
+                                    hasher = method(seed)
+                                    hasher.update(i_bytes[j : j + 8])
+                                    digest = hasher.digest()
+                                elif hash_name == "sha256":  # Not safe for seeded hashes, use HMAC
+                                    digest = hmac.new(
+                                        seed, i_bytes[j : j + 8], digestmod=method
+                                    ).digest()
                                 if fold_type == "full":
                                     return int.from_bytes(digest, "big") % 2**64
                                 else:  # "view"

--- a/vernamveil/__init__.py
+++ b/vernamveil/__init__.py
@@ -7,7 +7,7 @@ from vernamveil._fx_utils import (
     FX,
     check_fx_sanity,
     generate_default_fx,
-    generate_keyed_hash_fx,
+    generate_hash_prf_fx,
     generate_polynomial_fx,
     load_fx_from_file,
 )
@@ -29,7 +29,7 @@ __all__ = [
     "fold_bytes_to_uint64",
     "forge_plausible_fx",
     "generate_default_fx",
-    "generate_keyed_hash_fx",
+    "generate_hash_prf_fx",
     "generate_polynomial_fx",
     "hash_numpy",
     "load_fx_from_file",

--- a/vernamveil/_fx_utils.py
+++ b/vernamveil/_fx_utils.py
@@ -19,7 +19,7 @@ __all__ = [
     "FX",
     "check_fx_sanity",
     "generate_default_fx",
-    "generate_keyed_hash_fx",
+    "generate_hash_prf_fx",
     "generate_polynomial_fx",
     "load_fx_from_file",
 ]
@@ -96,18 +96,18 @@ class FX:
         return self.keystream_fn(i, seed)
 
 
-def generate_keyed_hash_fx(
+def generate_hash_prf_fx(
     hash_name: Literal["blake2b", "sha256"] = "blake2b",
     vectorise: bool = False,
 ) -> FX:
-    """Generate a standard keyed hash-based pseudorandom function (PRF) using Blake2b or SHA256.
+    """Generate a standard hash-based pseudorandom function (PRF) using Blake2b or SHA256.
 
     Args:
         hash_name (Literal["blake2b", "sha256"]): Hash function to use ("blake2b" or "sha256"). Defaults to "blake2b".
         vectorise (bool): If True, uses numpy arrays as input for vectorised operations. Defaults to False.
 
     Returns:
-        FX: A callable that returns pseudo-random bytes from keyed hash-based function.
+        FX: A callable that returns pseudo-random bytes from hash-based function.
 
     Raises:
         ValueError: If `hash_name` is not "blake2b" or "sha256".
@@ -121,7 +121,7 @@ def generate_keyed_hash_fx(
     if not isinstance(vectorise, bool):
         raise TypeError("vectorise must be a boolean.")
 
-    # Dynamically generate the function code for scalar or vectorised keyed hash-based PRF
+    # Dynamically generate the function code for scalar or vectorised hash-based PRF
     if vectorise:
         function_code = f"""
 import numpy as np
@@ -129,11 +129,11 @@ from vernamveil import FX, hash_numpy
 
 
 def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
-    # Implements a standard keyed hash-based pseudorandom function (PRF) using {hash_name}.
+    # Implements a standard hash-based pseudorandom function (PRF) using {hash_name}.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
-    # Security relies entirely on the secrecy of the seed and the cryptographic strength of the keyed hash.
+    # Security relies entirely on the secrecy of the seed and the cryptographic strength of the hash.
 
-    # Cryptographic keyed hash using {hash_name}
+    # Cryptographic hash using {hash_name}
     return hash_numpy(i, seed, "{hash_name}")  # uses C module if available, else NumPy fallback
 """
     else:
@@ -143,11 +143,11 @@ from vernamveil import FX
 
 
 def keystream_fn(i: int, seed: bytes) -> bytes:
-    # Implements a standard keyed hash-based pseudorandom function (PRF) using {hash_name}.
+    # Implements a standard hash-based pseudorandom function (PRF) using {hash_name}.
     # The output is deterministically derived from the input index `i` and the secret `seed`.
-    # Security relies entirely on the secrecy of the seed and the cryptographic strength of the keyed hash.
+    # Security relies entirely on the secrecy of the seed and the cryptographic strength of the hash.
 
-    # Cryptographic keyed hash using {hash_name}
+    # Cryptographic hash using {hash_name}
     hasher = hashlib.new(hash_name, key=seed)
     hasher.update(i.to_bytes(8, "big"))
     return hasher.digest()
@@ -226,8 +226,8 @@ def make_keystream_fn():
 
     def keystream_fn(i: np.ndarray, seed: bytes) -> np.ndarray:
         # Implements a customisable fx function based on a {degree}-degree polynomial transformation of the index,
-        # followed by a cryptographically secure keyed hash (Blake2b) output.
-        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the keyed hash.
+        # followed by a cryptographically secure hash (Blake2b) output.
+        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the hash.
         # The polynomial transformation adds uniqueness to each fx instance but does not contribute additional entropy.
 
         # Transform index i using a polynomial function to introduce uniqueness on fx
@@ -236,7 +236,7 @@ def make_keystream_fn():
         # Weighted sum (polynomial evaluation)
         result = np.dot(powers, weights)
 
-        # Cryptographic keyed hash using Blake2b
+        # Cryptographic hash using Blake2b
         return hash_numpy(result, seed, "blake2b")  # uses C module if available, else NumPy fallback
 
     return keystream_fn
@@ -253,8 +253,8 @@ def make_keystream_fn():
 
     def keystream_fn(i: int, seed: bytes) -> bytes:
         # Implements a customisable fx function based on a {degree}-degree polynomial transformation of the index,
-        # followed by a cryptographically secure keyed hash (Blake2b) output.
-        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the keyed hash.
+        # followed by a cryptographically secure hash (Blake2b) output.
+        # Note: The security of `fx` relies entirely on the secrecy of the seed and the strength of the hash.
         # The polynomial transformation adds uniqueness to each fx instance but does not contribute additional entropy.
 
         # Transform index i using a polynomial function to introduce uniqueness on fx
@@ -264,7 +264,7 @@ def make_keystream_fn():
             result = (result + weight * current_pow) & 0xFFFFFFFFFFFFFFFF
             current_pow = (current_pow * i) & 0xFFFFFFFFFFFFFFFF
 
-        # Cryptographic keyed hash using Blake2b
+        # Cryptographic hash using Blake2b
         hasher = hashlib.blake2b(seed)
         hasher.update(i.to_bytes(8, "big"))
         return hasher.digest()

--- a/vernamveil/_hash_utils.py
+++ b/vernamveil/_hash_utils.py
@@ -4,6 +4,7 @@ This module provides fast, optionally C-accelerated hashing functions for use in
 """
 
 import hashlib
+import hmac
 from typing import Literal
 
 try:
@@ -114,12 +115,19 @@ def hash_numpy(
             ffi.from_buffer(out.data),
         )
     else:
-        i_bytes = i.view(np.uint8)
+        i_bytes = i.view(np.uint8).data
         for idx, j in enumerate(range(0, len(i_bytes), 8)):
-            hasher = method()
-            if seed is not None:
-                hasher.update(seed)
-            hasher.update(i_bytes.data[j : j + 8])
-            out[idx, :] = np.frombuffer(hasher.digest(), dtype=np.uint8)
+            if hash_name == "blake2b":
+                hasher = method()
+                if seed is not None:
+                    hasher.update(seed)
+                hasher.update(i_bytes[j : j + 8])
+                digest = hasher.digest()
+            elif hash_name == "sha256":
+                if seed is not None:  # Not safe for seeded hashes, use HMAC
+                    digest = hmac.new(seed, i_bytes[j : j + 8], digestmod=method).digest()
+                else:
+                    digest = method(i_bytes[j : j + 8]).digest()
+            out[idx, :] = np.frombuffer(digest, dtype=np.uint8)
 
     return out


### PR DESCRIPTION
Technically SHA256 is not safe for keyed Hashing, due to vulnerability to length-extension attacks. Nevertheless, the algorithm is not used in our hashing constructions (we use Blake2b instead), so the extra complexity in the codebase is not worth it.