### PR TITLE
Add HKDF-Expand implementation

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
           python -m pip install .[dev,numpy,cffi]
           cd nphash
           python build.py
-          ls -lh _npblake2bffi.* _npsha256ffi.*
+          ls -lh _npblake2bffi.* _nphkdfffi.* _npsha256ffi.*
           cd ..
           python -m pip install .
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
               sudo apt-get update && sudo apt-get install -y build-essential libssl-dev python3-dev
               cd nphash
               python build.py
-              ls -lh _npblake2bffi.* _npsha256ffi.*
+              ls -lh _npblake2bffi.* _nphkdfffi.* _npsha256ffi.*
               cd ..
               python -m pip install .
 
@@ -35,7 +35,7 @@ jobs:
               brew install libomp openssl
               cd nphash
               python build.py
-              ls -lh _npblake2bffi.* _npsha256ffi.*
+              ls -lh _npblake2bffi.* _nphkdfffi.* _npsha256ffi.*
               cd ..
               python -m pip install .
 
@@ -45,7 +45,7 @@ jobs:
               choco install openssl --no-progress -y
               cd nphash
               python build.py
-              dir _npblake2bffi.* _npsha256ffi.*
+              dir _npblake2bffi.* _nphkdfffi.* _npsha256ffi.*
               cd ..
               python -m pip install .
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 dist/
 docs-html/
 .env
-nphash/_npsha256ffi*
 nphash/_npblake2bffi*
+nphash/_nphkdfffi*
+nphash/_npsha256ffi*
 reports/

--- a/docs/fx_utils.rst
+++ b/docs/fx_utils.rst
@@ -22,4 +22,5 @@ Fx Utilities
 
 .. autofunction:: generate_keyed_hash_fx
 .. autofunction:: generate_polynomial_fx
+.. autofunction:: generate_prf_fx
 .. autofunction:: load_fx_from_file

--- a/docs/hash_utils.rst
+++ b/docs/hash_utils.rst
@@ -5,3 +5,4 @@ Hash Utilities
 
 .. autofunction:: fold_bytes_to_uint64
 .. autofunction:: hash_numpy
+.. autofunction:: hkdf_numpy

--- a/nphash/README.md
+++ b/nphash/README.md
@@ -1,6 +1,6 @@
 # Building the `nphash` C Library with `build.py`
 
-This project provides an optional C extension called `nphash` to efficiently compute BLAKE2b and SHA-256 based hashes from Python. The Python method `hash_numpy` can be used in `fx` methods to quickly produce required keyed hashing in vectorised implementations.
+This project provides an optional C extension called `nphash` to efficiently compute BLAKE2b and SHA-256 based hashes from Python. The Python method `hash_numpy` can be used in `fx` methods to quickly produce required keyed hashing in vectorised implementations. Moreover, it provides `hkdf_numpy` for fast HKDF key derivation.
 
 The C code is compiled and wrapped for Python using the [cffi](https://cffi.readthedocs.io/en/latest/) library.
 
@@ -58,7 +58,7 @@ Supported platforms: Linux, macOS, and Windows (with suitable build tools).
    python build.py
    ```
 
-   This will compile the C code and generate libraries named `_npblake2bffi.*.so` and `_npsha256ffi.*.so` (the exact filenames depend on your platform and Python version).
+   This will compile the C code and generate libraries named `_npblake2bffi.*.so`, ` _nphkdfffi.*.so` and `_npsha256ffi.*.so` (the exact filenames depend on your platform and Python version).
 
 4. **Reinstall the library**
 
@@ -80,12 +80,12 @@ from vernamveil._hash_utils import _HAS_C_MODULE
 After building, you can use the extension from Python code:
 
 ```python
-from vernamveil import hash_numpy
-# hash_numpy will use the C extension if available, otherwise a pure NumPy fallback.
+from vernamveil import hash_numpy, hkdf_numpy
+# They will use the C extension if available, otherwise a pure NumPy/Python fallback.
 # Both BLAKE2b and SHA-256 are supported via the C extension.
 ```
 
-If the C extension is not built or importable, `hash_numpy` will transparently fall back to a slower pure NumPy implementation. No code changes are needed.
+If the C extension is not built or importable, `hash_numpy` and `hkdf_numpy` will transparently fall back to a slower pure NumPy implementation. No code changes are needed.
 
 ## Notes
 

--- a/nphash/__init__.py
+++ b/nphash/__init__.py
@@ -3,6 +3,7 @@
 from types import ModuleType
 
 _npblake2bffi: ModuleType
+_nphkdfffi: ModuleType
 _npsha256ffi: ModuleType
 
 __all__: list[str] = []

--- a/nphash/_nphkdf.c
+++ b/nphash/_nphkdf.c
@@ -1,0 +1,44 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/kdf.h>
+
+// HKDF Expand-only: key = seed, info = info, digest = blake2b/sha256, out = keystream
+// Returns 0 on success, -1 on error
+int numpy_hkdf(const unsigned char* key,
+               const size_t keylen,
+               const char* digest_name,
+               const unsigned char* info,
+               size_t infolen,
+               size_t outlen,
+               uint8_t* restrict out) {
+    // Select the digest algorithm based on the input string
+    const EVP_MD* md =
+        (strcmp(digest_name, "blake2b") == 0) ? EVP_blake2b512() :
+        (strcmp(digest_name, "sha256") == 0) ? EVP_sha256() : NULL;
+
+    // Fail early if digest is not available
+    if (!md)
+        return -1;
+
+    // Create a new HKDF context for key derivation
+    EVP_PKEY_CTX* pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
+
+    // Check if the context was created successfully
+    bool ok = pctx;
+
+    // Perform HKDF key derivation
+    ok &= EVP_PKEY_derive_init(pctx) > 0;
+    ok &= EVP_PKEY_CTX_set_hkdf_mode(pctx, EVP_PKEY_HKDEF_MODE_EXPAND_ONLY) > 0;
+    ok &= EVP_PKEY_CTX_set_hkdf_md(pctx, md) > 0;
+    ok &= EVP_PKEY_CTX_set1_hkdf_key(pctx, key, (int)keylen) > 0;
+    ok &= EVP_PKEY_CTX_add1_hkdf_info(pctx, info, (int)infolen) > 0;
+    ok &= EVP_PKEY_derive(pctx, out, &outlen) > 0;
+
+    // Free the HKDF context to avoid memory leaks
+    EVP_PKEY_CTX_free(pctx);
+
+    // Return 0 on success, -1 on failure
+    return ok ? 0 : -1;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,4 +57,4 @@ include = ["vernamveil", "nphash"]
 
 [tool.setuptools.package-data]
 "vernamveil" = ["py.typed"]
-"nphash" = ["py.typed", "_npblake2bffi.*.so", "_npsha256ffi.*.so"]
+"nphash" = ["py.typed", "_npblake2bffi.*.so", "_nphkdfffi.*.so", "_npsha256ffi.*.so"]

--- a/vernamveil/__init__.py
+++ b/vernamveil/__init__.py
@@ -10,9 +10,10 @@ from vernamveil._fx_utils import (
     generate_default_fx,
     generate_keyed_hash_fx,
     generate_polynomial_fx,
+    generate_prf_fx,
     load_fx_from_file,
 )
-from vernamveil._hash_utils import fold_bytes_to_uint64, hash_numpy
+from vernamveil._hash_utils import fold_bytes_to_uint64, hash_numpy, hkdf_numpy
 from vernamveil._vernamveil import VernamVeil
 
 __version__: str
@@ -33,6 +34,8 @@ __all__ = [
     "generate_default_fx",
     "generate_keyed_hash_fx",
     "generate_polynomial_fx",
+    "generate_prf_fx",
     "hash_numpy",
+    "hkdf_numpy",
     "load_fx_from_file",
 ]


### PR DESCRIPTION
Adds HKDF key derivation via a custom C extension. 

The approach is slower (comparable to the pre-HMAC change at #12) because internally it uses HMAC instead of keyed hash.