### PR TITLE
Experimental XOR then Obfuscate

### DIFF
--- a/tests/test_vernamveil.py
+++ b/tests/test_vernamveil.py
@@ -125,15 +125,6 @@ class TestVernamVeil(unittest.TestCase):
         self._for_all_modes(test, siv_seed_initialisation=True, auth_encrypt=False)
         self._for_all_modes(test, siv_seed_initialisation=False, auth_encrypt=False)
 
-    def test_delimiter_conflict_raises(self):
-        """Test that encoding fails if the delimiter appears in the message."""
-        cypher = VernamVeil(generate_default_fx())
-        cypher._delimiter_size = 1  # override to force a delimiter size of 1 byte
-        message = bytes(range(256))  # Message contains every possible byte value
-        with self.assertRaises(ValueError) as ctx:
-            cypher.encode(message, self.initial_seed)
-        self.assertIn("The delimiter appears in the message.", str(ctx.exception))
-
     def test_avalanche_effect(self):
         """Test that flipping a single bit in the input causes ~50% of output bits to change (avalanche effect)."""
         message = b"This is a test message for avalanche effect!"


### PR DESCRIPTION
This PR attempted to do first the encryption on the original message and then the obfuscation. This could have lead to better performance because we won't have to encode the delimiters, the padding and the random chunks. To ensure the delimiter is not leaked, we generate a new delimiter from the `_fx` for every use (so each delimiter is used once and is indistinguishable from the rest of bytes provided a strong uniform output fx). Despite the repeated delimiters, this approach should be faster because it doesn't have to create a keystream for them plus the savings from the noisy bits.

Unfortunately this wont work without storing meta-data in the cypher-text. The problem lies on the order of operations on obfuscate/deobfuscate:
- Obfuscate has to shuffle the indices first and then generate the delimiters.
- Deobfuscate has to generate delimiters first and then shuffle the indices. This is because the delimiters are used to recover the chunk ranges which in turn give us the `total_count` counter needed for the shuffling.
- Since shuffling requires just a seed, the problem for normal `fx` is solved by creating a purpose-specific seed for shuffling. 
- Nevertheless this won't work for OTP. The seed is not the problem; the problem is that the deobfuscate delimiter generation involves `fx()` calls that happen out-of-order from obfuscation. This desynchronises decoding.
- The reason why it works for `fx` based keystream generation but not OTP, is because `fx` depends on the seed which we can maintain intact. OTP doesn't depend on the seed causing the issue.
- Obviously since Plausible Deniability works with OTP under the hood, this causes issues there too.
- A potential fix is to store the `total_count` as meta-data in the cypherstream to make it recoverable without needing to generate the delimiters first. But this would render the cypher not "meta-data free". 
- An alternative approach could to generate the delimiters without involving the fx but rather directly from the seed. This would introduce a parallel way to produce bytes that doesn't depend on the fx. Though this exists already to a small degree, the `_determine_shuffled_indices` produces random indices from just the seed, we don't currently produce bytes there; just numbers. So this design choice feels justified. Generating bytes without the fx is problematic.
- Another approach that might solve this more elegantly is if the `delimiter_size` is linked to the `block_size`. This way, we won't be producing bytes but just rehashing the purpose-specific delimiter seed which already exists in the implementation. But this can be incredibly wasteful if on the future we introduce XOF for keystream generation (BLAKE2X, BLAKE3 etc). A XOF approach would make the `block_size` very large, potentially reducing the speed and significantly increasing the output size.

This PR is not complete and the tests fail. As all proposed approaches have serious side-effects on the cypher's design, I won't continue this implementation. 