### PR TITLE
Simplify blake3 Implementation

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install system dependencies and build C modules
         run: |
-          sudo apt-get update && sudo apt-get install -y build-essential libssl-dev python3-dev
+          sudo apt-get update && sudo apt-get install -y build-essential g++ libssl-dev libtbb-dev python3-dev
           python -m pip install .[dev,numpy,cffi]
           cd nphash
           python build.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,23 +43,16 @@ jobs:
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
               @echo on
-              git clone https://github.com/microsoft/vcpkg.git
-              if errorlevel 1 echo "git clone failed" & exit /b %errorlevel%
-              .\vcpkg\bootstrap-vcpkg.bat
-              if errorlevel 1 echo "bootstrap-vcpkg.bat failed" & exit /b %errorlevel%
-              .\vcpkg\vcpkg.exe install tbb:x64-windows
-              if errorlevel 1 echo "vcpkg install failed" & exit /b %errorlevel%
-              copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
-              if errorlevel 1 echo "copy DLLs failed" & exit /b %errorlevel%
-              choco install openssl --no-progress -y
-              if errorlevel 1 echo "choco install failed" & exit /b %errorlevel%
-              cd nphash
-              python build.py
-              if errorlevel 1 echo "build.py failed" & exit /b %errorlevel%
-              dir _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*
-              cd ..
-              python -m pip install .
-              if errorlevel 1 echo "pip install failed" & exit /b %errorlevel%
+              git clone https://github.com/microsoft/vcpkg.git ^
+              && .\vcpkg\bootstrap-vcpkg.bat --disable-metrics ^
+              && .\vcpkg\vcpkg.exe install tbb:x64-windows ^
+              && copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\ ^
+              && choco install openssl --no-progress -y ^
+              && cd nphash ^
+              && python build.py ^
+              && dir _npblake2bffi.* _npblake3ffi.* _npsha256ffi.* ^
+              && cd .. ^
+              && python -m pip install .
 
     name: test_${{ matrix.os }}_${{ join(matrix.pip-dependencies, '_') }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,9 @@ jobs:
             build-steps: |
               @echo on
               git clone https://github.com/microsoft/vcpkg.git
-              cd vcpkg
-              .\bootstrap-vcpkg.bat -disableMetrics
-              IF %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
-              .\vcpkg.exe install tbb:x64-windows
-              IF %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
-              copy .\installed\x64-windows\bin\tbb*.dll ..\nphash\
+              .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+              .\vcpkg\vcpkg.exe install tbb:x64-windows
+              copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
               cd ..
               choco install openssl --no-progress -y
               cd nphash
@@ -85,6 +82,10 @@ jobs:
 
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
+
+      - name: Setup tmate session (for interactive SSH debugging)
+        if: matrix.os == 'windows-latest'
+        uses: mxschmitt/action-tmate@v3
 
       - name: Build/package steps (Windows)
         if: matrix.build-steps != '' && matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,10 @@ jobs:
           - os: windows-latest
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
-              curl -L -o tbb.zip https://github.com/uxlfoundation/oneTBB/releases/download/v2022.1.0/oneapi-tbb-2022.1.0-win.zip
-              7z x tbb.zip -otbb
-              set "INCLUDE=%CD%\tbb\oneapi-tbb-2022.1.0\include;%INCLUDE%"
-              set "LIB=%CD%\tbb\oneapi-tbb-2022.1.0\lib\intel64\vc14;%LIB%"
+              git clone https://github.com/microsoft/vcpkg.git
+              .\vcpkg\bootstrap-vcpkg.bat
+              .\vcpkg\vcpkg.exe install tbb:x64-windows
+              copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
               choco install openssl --no-progress -y
               cd nphash
               python build.py
@@ -91,9 +91,9 @@ jobs:
         run: ${{ matrix.build-steps }}
         shell: bash
 
-      - name: Setup tmate session (for interactive SSH debugging)
-        if: matrix.os == 'windows-latest'
-        uses: mxschmitt/action-tmate@v3
+#      - name: Setup tmate session (for interactive SSH debugging)
+#        if: matrix.os == 'windows-latest'
+#        uses: mxschmitt/action-tmate@v3
 
       - name: Run tests
         run: python -m unittest discover -s tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,11 @@ jobs:
             build-steps: |
               @echo on
               git clone https://github.com/microsoft/vcpkg.git
-              .\vcpkg\bootstrap-vcpkg.bat
-              .\vcpkg\vcpkg.exe install tbb:x64-windows
-              copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
+              cd vcpkg
+              .\bootstrap-vcpkg.bat -disableMetrics
+              .\vcpkg.exe install tbb:x64-windows
+              copy .\installed\x64-windows\bin\tbb*.dll ..\nphash\
+              cd ..
               choco install openssl --no-progress -y
               cd nphash
               python build.py
@@ -81,10 +83,6 @@ jobs:
 
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
-
-      - name: Setup tmate session (for interactive SSH debugging)
-        if: matrix.os == 'windows-latest'
-        uses: mxschmitt/action-tmate@v3
 
       - name: Build/package steps (Windows)
         if: matrix.build-steps != '' && matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           - os: windows-latest
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
+              @echo on
               git clone https://github.com/microsoft/vcpkg.git
               .\vcpkg\bootstrap-vcpkg.bat
               .\vcpkg\vcpkg.exe install tbb:x64-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
               copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
               set INCLUDE=%CD%\vcpkg\installed\x64-windows\include;%INCLUDE%
               set LIB=%CD%\vcpkg\installed\x64-windows\lib;%LIB%
-              cd ..
               choco install openssl --no-progress -y
               cd nphash
               python build.py
@@ -84,10 +83,6 @@ jobs:
 
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
-
-      - name: Setup tmate session (for interactive SSH debugging)
-        if: matrix.os == 'windows-latest'
-        uses: mxschmitt/action-tmate@v3
 
       - name: Build/package steps (Windows)
         if: matrix.build-steps != '' && matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
               brew install libomp openssl tbb
-              export CXXFLAGS="-std=c++11"
               cd nphash
               python build.py
               ls -lh _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,15 +44,22 @@ jobs:
             build-steps: |
               @echo on
               git clone https://github.com/microsoft/vcpkg.git
+              if errorlevel 1 echo "git clone failed" & exit /b %errorlevel%
               .\vcpkg\bootstrap-vcpkg.bat
+              if errorlevel 1 echo "bootstrap-vcpkg.bat failed" & exit /b %errorlevel%
               .\vcpkg\vcpkg.exe install tbb:x64-windows
+              if errorlevel 1 echo "vcpkg install failed" & exit /b %errorlevel%
               copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
+              if errorlevel 1 echo "copy DLLs failed" & exit /b %errorlevel%
               choco install openssl --no-progress -y
+              if errorlevel 1 echo "choco install failed" & exit /b %errorlevel%
               cd nphash
               python build.py
+              if errorlevel 1 echo "build.py failed" & exit /b %errorlevel%
               dir _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*
               cd ..
               python -m pip install .
+              if errorlevel 1 echo "pip install failed" & exit /b %errorlevel%
 
     name: test_${{ matrix.os }}_${{ join(matrix.pip-dependencies, '_') }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
               .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
               .\vcpkg\vcpkg.exe install tbb:x64-windows
               copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
+              set INCLUDE=%CD%\vcpkg\installed\x64-windows\include;%INCLUDE%
+              set LIB=%CD%\vcpkg\installed\x64-windows\lib;%LIB%
               cd ..
               choco install openssl --no-progress -y
               cd nphash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,6 @@ jobs:
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
               @echo on
-              git clone https://github.com/microsoft/vcpkg.git
-              call .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
-              call .\vcpkg\vcpkg.exe install tbb:x64-windows
               copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
               set INCLUDE=%CD%\vcpkg\installed\x64-windows\include;%INCLUDE%
               set LIB=%CD%\vcpkg\installed\x64-windows\lib;%LIB%
@@ -84,15 +81,32 @@ jobs:
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
 
-      - name: Build/package steps (Windows)
-        if: matrix.build-steps != '' && matrix.os == 'windows-latest'
-        run: ${{ matrix.build-steps }}
-        shell: cmd
-
       - name: Build/package steps (non-Windows)
         if: matrix.build-steps != '' && matrix.os != 'windows-latest'
         run: ${{ matrix.build-steps }}
         shell: bash
+
+      - name: Cache vcpkg and TBB (Windows only)
+        if: matrix.os == 'windows-latest' && join(matrix.pip-dependencies, '_') == 'dev_numpy_cffi'
+        uses: actions/cache@v4
+        with:
+          path: vcpkg
+          key: vcpkg_windows-latest_dev_numpy_cffi
+
+      - name: vcpkg + TBB setup (Windows only)
+        if: matrix.os == 'windows-latest' && join(matrix.pip-dependencies, '_') == 'dev_numpy_cffi'
+        run: |
+          if not exist vcpkg (
+            git clone https://github.com/microsoft/vcpkg.git
+            call .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+            call .\vcpkg\vcpkg.exe install tbb:x64-windows
+          )
+        shell: cmd
+
+      - name: Build/package steps (Windows)
+        if: matrix.build-steps != '' && matrix.os == 'windows-latest'
+        run: ${{ matrix.build-steps }}
+        shell: cmd
 
 #      - name: Setup tmate session (for interactive SSH debugging)
 #        if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
             build-steps: |
               curl -L -o tbb.zip https://github.com/uxlfoundation/oneTBB/releases/download/v2022.1.0/oneapi-tbb-2022.1.0-win.zip
               7z x tbb.zip -otbb
-              export INCLUDE="$PWD/tbb/oneapi-tbb-2022.1.0/include:$INCLUDE"
-              export LIB="$PWD/tbb/oneapi-tbb-2022.1.0/lib/intel64/vc14:$LIB"
+              set "INCLUDE=%CD%\tbb\oneapi-tbb-2022.1.0\include;%INCLUDE%"
+              set "LIB=%CD%\tbb\oneapi-tbb-2022.1.0\lib\intel64\vc14;%LIB%"
               choco install openssl --no-progress -y
               cd nphash
               python build.py
@@ -81,14 +81,14 @@ jobs:
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
 
-      - name: Setup tmate session (for interactive SSH debugging)
-        if: matrix.os == 'windows-latest'
-        uses: mxschmitt/action-tmate@v3
+#      - name: Setup tmate session (for interactive SSH debugging)
+#        if: matrix.os == 'windows-latest'
+#        uses: mxschmitt/action-tmate@v3
 
       - name: Build/package steps
         if: matrix.build-steps != ''
         run: ${{ matrix.build-steps }}
-        shell: bash
+        shell: ${{ matrix.os == 'windows-latest' && 'cmd' || 'bash' }}
 
       - name: Run tests
         run: python -m unittest discover -s tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
               git clone https://github.com/microsoft/vcpkg.git
               cd vcpkg
               .\bootstrap-vcpkg.bat -disableMetrics
+              IF %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
               .\vcpkg.exe install tbb:x64-windows
+              IF %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
               copy .\installed\x64-windows\bin\tbb*.dll ..\nphash\
               cd ..
               choco install openssl --no-progress -y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,9 @@ jobs:
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
 
-#      - name: Setup tmate session (for interactive SSH debugging)
-#        if: matrix.os == 'windows-latest'
-#        uses: mxschmitt/action-tmate@v3
+      - name: Setup tmate session (for interactive SSH debugging)
+        if: matrix.os == 'windows-latest'
+        uses: mxschmitt/action-tmate@v3
 
       - name: Build/package steps
         if: matrix.build-steps != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
               brew install libomp openssl tbb
+              export CXXFLAGS="-std=c++11"
               cd nphash
               python build.py
               ls -lh _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,15 @@ jobs:
 #        if: matrix.os == 'windows-latest'
 #        uses: mxschmitt/action-tmate@v3
 
-      - name: Build/package steps
-        if: matrix.build-steps != ''
+      - name: Build/package steps (Windows)
+        if: matrix.build-steps != '' && matrix.os == 'windows-latest'
         run: ${{ matrix.build-steps }}
-        shell: ${{ matrix.os == 'windows-latest' && 'cmd' || 'bash' }}
+        shell: cmd
+
+      - name: Build/package steps (non-Windows)
+        if: matrix.build-steps != '' && matrix.os != 'windows-latest'
+        run: ${{ matrix.build-steps }}
+        shell: bash
 
       - name: Run tests
         run: python -m unittest discover -s tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - os: ubuntu-latest
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
-              sudo apt-get update && sudo apt-get install -y build-essential libssl-dev python3-dev
+              sudo apt-get update && sudo apt-get install -y build-essential g++ libssl-dev libtbb-dev python3-dev
               cd nphash
               python build.py
               ls -lh _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*
@@ -32,7 +32,7 @@ jobs:
           - os: macos-latest
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
-              brew install libomp openssl
+              brew install libomp openssl tbb
               cd nphash
               python build.py
               ls -lh _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*
@@ -42,7 +42,7 @@ jobs:
           - os: windows-latest
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
-              choco install openssl --no-progress -y
+              choco install openssl tbb --no-progress -y
               cd nphash
               python build.py
               dir _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
 
+      - name: Setup tmate session (for interactive SSH debugging)
+        if: matrix.os == 'windows-latest'
+        uses: mxschmitt/action-tmate@v3
+
       - name: Build/package steps (Windows)
         if: matrix.build-steps != '' && matrix.os == 'windows-latest'
         run: ${{ matrix.build-steps }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,6 @@ jobs:
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
 
-#      - name: Setup tmate session (for interactive SSH debugging)
-#        if: matrix.os == 'windows-latest'
-#        uses: mxschmitt/action-tmate@v3
-
       - name: Build/package steps (Windows)
         if: matrix.build-steps != '' && matrix.os == 'windows-latest'
         run: ${{ matrix.build-steps }}
@@ -94,6 +90,10 @@ jobs:
         if: matrix.build-steps != '' && matrix.os != 'windows-latest'
         run: ${{ matrix.build-steps }}
         shell: bash
+
+      - name: Setup tmate session (for interactive SSH debugging)
+        if: matrix.os == 'windows-latest'
+        uses: mxschmitt/action-tmate@v3
 
       - name: Run tests
         run: python -m unittest discover -s tests/ -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,16 +43,16 @@ jobs:
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
               @echo on
-              git clone https://github.com/microsoft/vcpkg.git ^
-              && .\vcpkg\bootstrap-vcpkg.bat --disable-metrics ^
-              && .\vcpkg\vcpkg.exe install tbb:x64-windows ^
-              && copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\ ^
-              && choco install openssl --no-progress -y ^
-              && cd nphash ^
-              && python build.py ^
-              && dir _npblake2bffi.* _npblake3ffi.* _npsha256ffi.* ^
-              && cd .. ^
-              && python -m pip install .
+              git clone https://github.com/microsoft/vcpkg.git
+              .\vcpkg\bootstrap-vcpkg.bat --disable-metrics
+              .\vcpkg\vcpkg.exe install tbb:x64-windows
+              copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
+              choco install openssl --no-progress -y
+              cd nphash
+              python build.py
+              dir _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*
+              cd ..
+              python -m pip install .
 
     name: test_${{ matrix.os }}_${{ join(matrix.pip-dependencies, '_') }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,11 @@ jobs:
           - os: windows-latest
             pip-dependencies: [dev, numpy, cffi]
             build-steps: |
-              choco install openssl tbb --no-progress -y
+              curl -L -o tbb.zip https://github.com/uxlfoundation/oneTBB/releases/download/v2022.1.0/oneapi-tbb-2022.1.0-win.zip
+              7z x tbb.zip -otbb
+              export INCLUDE="$PWD/tbb/oneapi-tbb-2022.1.0/include:$INCLUDE"
+              export LIB="$PWD/tbb/oneapi-tbb-2022.1.0/lib/intel64/vc14:$LIB"
+              choco install openssl --no-progress -y
               cd nphash
               python build.py
               dir _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*
@@ -76,6 +80,10 @@ jobs:
 
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
+
+#      - name: Setup tmate session (for interactive SSH debugging)
+#        if: matrix.os == 'windows-latest'
+#        uses: mxschmitt/action-tmate@v3
 
       - name: Build/package steps
         if: matrix.build-steps != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
             build-steps: |
               @echo on
               git clone https://github.com/microsoft/vcpkg.git
-              .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
-              .\vcpkg\vcpkg.exe install tbb:x64-windows
+              call .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+              call .\vcpkg\vcpkg.exe install tbb:x64-windows
               copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
               set INCLUDE=%CD%\vcpkg\installed\x64-windows\include;%INCLUDE%
               set LIB=%CD%\vcpkg\installed\x64-windows\lib;%LIB%
@@ -83,10 +83,6 @@ jobs:
 
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
-
-      - name: Setup tmate session (for interactive SSH debugging)
-        if: matrix.os == 'windows-latest'
-        uses: mxschmitt/action-tmate@v3
 
       - name: Build/package steps (Windows)
         if: matrix.build-steps != '' && matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
             build-steps: |
               @echo on
               git clone https://github.com/microsoft/vcpkg.git
-              .\vcpkg\bootstrap-vcpkg.bat --disable-metrics
+              .\vcpkg\bootstrap-vcpkg.bat
               .\vcpkg\vcpkg.exe install tbb:x64-windows
               copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
               choco install openssl --no-progress -y
@@ -81,6 +81,10 @@ jobs:
 
       - name: Install Python dependencies and library
         run: python -m pip install .[${{ join(matrix.pip-dependencies, ',') }}]
+
+      - name: Setup tmate session (for interactive SSH debugging)
+        if: matrix.os == 'windows-latest'
+        uses: mxschmitt/action-tmate@v3
 
       - name: Build/package steps (Windows)
         if: matrix.build-steps != '' && matrix.os == 'windows-latest'

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 build/
 dist/
 docs-html/
+nphash/*.o
 nphash/_npblake2bffi*
 nphash/_npblake3ffi*
 nphash/_npsha256ffi*

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ When creating your own key stream function (`fx`), it is essential to follow bes
 - **Avoid Data-Dependent Branching or Timing**: Do not introduce data-dependent branching or timing in your `fx`, as this can lead to side-channel attacks.
 - **Performance**: Complex or slow `fx` functions will slow down encryption and decryption. Test performance if speed is important for your use case.
 
-**Recommended approach:**  
+**Recommended approach:**
 Apply a unique transformation to the input index using a function that incorporates constant but randomly sampled parameters to make each `fx` instance unpredictable. Then, combine the result with the secret seed using a cryptographically secure keyed hash method or HMAC. This ensures your keystream is both unpredictable and securely bound to your secret.
 
 **Always test your custom `fx`** with the provided `check_fx_sanity` utility before using it for encryption. Note that this method only performs very basic checks and cannot guarantee cryptographic security; it may catch common mistakes, but passing all checks does not mean your function is secure.
@@ -316,7 +316,7 @@ decrypted_message = cypher.decrypt(encrypted_message, initial_seed)
 
 **Note:** The keystream must be truly random, at least as long as the message, and never reused. Reusing a keystream completely breaks the security of OTP encryption.
 
-> **Warning:**  
+> **Warning:**
 > Do **not** use or test your `OTPFX` instance (e.g., by calling it or running sanity checks) before actual encryption or decryption. Any use will consume part of the keystream, which cannot be recovered, and will cause decryption to fail. Always use a fresh, unused `OTPFX` instance for each encryption/decryption operation or reset its `fx.position` to `0`.
 
 ---
@@ -325,7 +325,7 @@ decrypted_message = cypher.decrypt(encrypted_message, initial_seed)
 
 VernamVeil includes helper tools to make working with key stream functions easier:
 
-- `OTPFX`: A callable wrapper for using externally generated, one-time-pad keystreams as a drop-in replacement for function-based `fx`. 
+- `OTPFX`: A callable wrapper for using externally generated, one-time-pad keystreams as a drop-in replacement for function-based `fx`.
 - `check_fx_sanity`: Runs basic sanity checks on your custom `fx` to ensure it produces diverse and seed-sensitive outputs.
 - `generate_keyed_hash_fx` (same as `generate_default_fx`): Generates a deterministic `fx` function that applies a specified hash algorithm (e.g., BLAKE2b, BLAKE3 or SHA-256) directly to the index and seed. The seed is the only secret key but the keyed hash is a cryptographically strong and proven `fx`. Supports both scalar and vectorised (NumPy) modes. This is the recommended secure default `fx` for the VernamVeil cypher. The BLAKE3 option is only available with the C extension.
 - `generate_polynomial_fx`: Generates a random `fx` function that first transforms the index using a polynomial with random weights, then applies keyed hashing (BLAKE2b) for cryptographic output. Supports both scalar and vectorised (NumPy) modes.
@@ -451,7 +451,7 @@ See `vernamveil encode --help` and `vernamveil decode --help` for all available 
 
 - **Compact Implementation**: The core cypher implementation (`_vernamveil.py`) is about 200 lines of code, excluding comments, documentation and empty lines.
 - **External Dependencies**: Built using only Python's standard library, with NumPy being optional for vectorisation.
-- **Optional C Module for Fast Hashing**: Includes an optional C module (`nphash`) built with [cffi](https://cffi.readthedocs.io/), enabling fast BLAKE2b, BLAKE3 and SHA-256 keyed hashing for vectorised `fx` functions. See the [`nphash` README](nphash/README.md) for details.
+- **Optional C/C++ Module for Fast Hashing**: Includes an optional C/C++ module (`nphash`) built with [cffi](https://cffi.readthedocs.io/), enabling fast BLAKE2b, BLAKE3 and SHA-256 keyed hashing for vectorised `fx` functions. The extension includes both C and C++ code (the C++ component is from the BLAKE3 project), so both a C and a C++ compiler (e.g., gcc and g++) are required to build it. See the [`nphash` README](nphash/README.md) for details.
 - **Tested with**: Python 3.10 and NumPy 2.2.5.
 
 ### 🔧 Installation
@@ -544,3 +544,4 @@ Contributions, bug reports, and feature requests are welcome! Please open an iss
 Copyright (C) 2025 [Vasilis Vryniotis](http://blog.datumbox.com/author/bbriniotis/).
 
 The code is licensed under the [Apache License, Version 2.0](https://github.com/datumbox/VernamVeil/blob/main/LICENSE).
+

--- a/nphash/README.md
+++ b/nphash/README.md
@@ -2,11 +2,11 @@
 
 This project provides an optional C extension called `nphash` to efficiently compute BLAKE2b, BLAKE3 and SHA-256 based hashes from Python. The Python method `hash_numpy` can be used in `fx` methods to quickly produce required keyed hashing in vectorised implementations. We also provide a `blake3` class, which offers a hashlib-style BLAKE3 hash object using the C backend. **The `blake3` implementation is only available when the C extension is built.**
 
-The C code is compiled and wrapped for Python using the [cffi](https://cffi.readthedocs.io/en/latest/) library.
+The C and C++ code is compiled and wrapped for Python using the [cffi](https://cffi.readthedocs.io/en/latest/) library.
 
 > **Note:** The C extension is optional. If it fails to build or is unavailable, VernamVeil will transparently fall back to a pure Python/NumPy implementation (with reduced performance).
 
-> **Note:** The `build.py` script will automatically download the required BLAKE3 C source files from the [official BLAKE3 repository](https://github.com/BLAKE3-team/BLAKE3) if they are not already present locally.
+> **Note:** The `build.py` script will automatically download the required BLAKE3 C and C++ source files from the [official BLAKE3 repository](https://github.com/BLAKE3-team/BLAKE3) if they are not already present locally.
 
 ## Prerequisites
 
@@ -14,8 +14,8 @@ Before building, ensure you have the following dependencies installed:
 
 - **Python 3.10 or later**
 - **pip** (Python package manager)
-- **gcc** (GNU Compiler Collection)
-- **OpenMP** (usually included with gcc)
+- **gcc/g++** (GNU Compiler Collection, including C++ support)
+- **OpenMP** (usually included with gcc/g++)
 - **OpenSSL development libraries**
 - **TBB (Threading Building Blocks) development libraries**
 - **cffi** and **numpy** Python packages

--- a/nphash/README.md
+++ b/nphash/README.md
@@ -42,10 +42,27 @@ Supported platforms: Linux, macOS, and Windows (with suitable build tools).
    brew install libomp openssl tbb
    ```
    
-   On Windows (with Chocolatey):
+   On Windows (with Chocolatey and vcpkg):
+   
+   1. Install OpenSSL with Chocolatey:
    ```bash
-   choco install openssl tbb
+   choco install openssl
    ```
+   2. Install tbb with [vcpkg](https://github.com/microsoft/vcpkg):
+      ```bash
+      git clone https://github.com/microsoft/vcpkg.git
+      .\vcpkg\bootstrap-vcpkg.bat -disableMetrics
+      .\vcpkg\vcpkg.exe install tbb:x64-windows
+      ```
+   3. Copy the TBB DLLs to your build directory (if needed):
+      ```bash
+      copy .\vcpkg\installed\x64-windows\bin\tbb*.dll nphash\
+      ```
+   4. Set the environment variables for include and lib paths (for the current session):
+      ```bash
+      set INCLUDE=%CD%\vcpkg\installed\x64-windows\include;%INCLUDE%
+      set LIB=%CD%\vcpkg\installed\x64-windows\lib;%LIB%
+      ```
 
 2. **Install Python dependencies**
 

--- a/nphash/README.md
+++ b/nphash/README.md
@@ -17,6 +17,7 @@ Before building, ensure you have the following dependencies installed:
 - **gcc** (GNU Compiler Collection)
 - **OpenMP** (usually included with gcc)
 - **OpenSSL development libraries**
+- **TBB (Threading Building Blocks) development libraries**
 - **cffi** and **numpy** Python packages
 
 Supported platforms: Linux, macOS, and Windows (with suitable build tools).
@@ -28,22 +29,22 @@ Supported platforms: Linux, macOS, and Windows (with suitable build tools).
    On Ubuntu/Debian:  
    ```bash
    sudo apt-get update
-   sudo apt-get install build-essential libssl-dev python3-dev
+   sudo apt-get install build-essential g++ libssl-dev libtbb-dev python3-dev
    ```
 
    On Fedora:  
    ```bash
-   sudo dnf install gcc openssl-devel python3-devel
+   sudo dnf install gcc gcc-c++ openssl-devel python3-devel tbb-devel
    ```
 
    On Mac (with Homebrew):
    ```bash
-   brew install libomp openssl
+   brew install libomp openssl tbb
    ```
    
    On Windows (with Chocolatey):
    ```bash
-   choco install openssl
+   choco install openssl tbb
    ```
 
 2. **Install Python dependencies**

--- a/nphash/_npblake3.c
+++ b/nphash/_npblake3.c
@@ -1,15 +1,8 @@
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
 #include "_npblake3.h"
 
-#ifdef __cplusplus
-#define _Atomic
-#endif
-
-// Define BLAKE3_USE_TBB before including blake3.h to enable the threaded API
-#define BLAKE3_USE_TBB 1
 #include "blake3.h"
 
 #ifdef _OPENMP
@@ -30,6 +23,7 @@ static inline void prepare_blake3_key(bool seeded, const char* seed, size_t seed
 // Inline helper to hash data with BLAKE3, with or without a key, and output variable-length hash
 // If parallel, uses blake3_hasher_update_tbb for multithreading
 static inline void blake3_hash_bytes(const uint8_t* data, size_t datalen, const uint8_t* key, bool seeded, uint8_t* out, size_t hash_size, bool parallel) {
+    // Initialise the BLAKE3 hasher
     blake3_hasher hasher;
     if (seeded) {
         // If a seed is provided, use it as the BLAKE3 key (up to 32 bytes, zero-padded if shorter)

--- a/nphash/_npblake3.c
+++ b/nphash/_npblake3.c
@@ -2,22 +2,25 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include "_npblake3.h"
 
+#ifdef __cplusplus
+#define _Atomic
+#endif
+
+// Define BLAKE3_USE_TBB before including blake3.h to enable the threaded API
+#define BLAKE3_USE_TBB 1
 #include "blake3.h"
 
 #ifdef _OPENMP
 // Enable parallelisation with OpenMP for multi-core performance
 #include <omp.h>
-#define CHUNK_SIZE 1024  // Size of each chunk in bytes for parallel processing
-#define MIN_PARALLEL_SIZE (2 * CHUNK_SIZE)  // Minimum size to enable parallel tree hashing
-#define BLAKE3_OUT_DOUBLE_LEN (2 * BLAKE3_OUT_LEN)  // Double the output length for combining CVs
-#define MIN(a, b) ((a) < (b) ? (a) : (b))  // Macro to find the minimum of two values
 #endif
 
 #define BLOCK_SIZE 8  // Each input element is a uint64 block
 
 // Inline helper to prepare a BLAKE3 key from a seed (up to 32 bytes, zero-padded if shorter)
-static inline void prepare_blake3_key(const bool seeded, const char* restrict seed, const size_t seedlen, uint8_t key[BLAKE3_KEY_LEN]) {
+static inline void prepare_blake3_key(bool seeded, const char* seed, size_t seedlen, uint8_t key[BLAKE3_KEY_LEN]) {
     if (seeded) {
         const size_t copylen = seedlen < BLAKE3_KEY_LEN ? seedlen : BLAKE3_KEY_LEN;
         memcpy(key, seed, copylen);
@@ -25,8 +28,8 @@ static inline void prepare_blake3_key(const bool seeded, const char* restrict se
 }
 
 // Inline helper to hash data with BLAKE3, with or without a key, and output variable-length hash
-static inline void blake3_hash_bytes(const uint8_t* restrict data, const size_t datalen, const uint8_t* restrict key, const bool seeded, uint8_t* restrict out, const size_t hash_size) {
-    // Initialise the BLAKE3 hasher
+// If parallel, uses blake3_hasher_update_tbb for multithreading
+static inline void blake3_hash_bytes(const uint8_t* data, size_t datalen, const uint8_t* key, bool seeded, uint8_t* out, size_t hash_size, bool parallel) {
     blake3_hasher hasher;
     if (seeded) {
         // If a seed is provided, use it as the BLAKE3 key (up to 32 bytes, zero-padded if shorter)
@@ -36,7 +39,11 @@ static inline void blake3_hash_bytes(const uint8_t* restrict data, const size_t 
         blake3_hasher_init(&hasher);
     }
     // Hash the data
-    blake3_hasher_update(&hasher, data, datalen);
+    if (parallel) {
+        blake3_hasher_update_tbb(&hasher, data, datalen);
+    } else {
+        blake3_hasher_update(&hasher, data, datalen);
+    }
     // Finalise the hash and write it to the output buffer (arbitrary length)
     blake3_hasher_finalize(&hasher, out, hash_size);
 }
@@ -45,11 +52,11 @@ static inline void blake3_hash_bytes(const uint8_t* restrict data, const size_t 
 // - If a seed is provided, the keyed mode is used by setting the key (up to 32 bytes, zero-padded if shorter)
 // - Output is a 2D uint8 array of shape n x hash_size (n rows, hash_size columns)
 // - hash_size can be any positive value (BLAKE3 is an XOF)
-void numpy_blake3(const uint64_t* restrict arr, const size_t n, const char* restrict seed, const size_t seedlen, uint8_t* restrict out, const size_t hash_size) {
+void numpy_blake3(const uint64_t* arr, size_t n, const char* seed, size_t seedlen, uint8_t* out, size_t hash_size) {
     // Input: native-endian uint64_t array; each element is hashed as an 8-byte block
     const unsigned char (*arr8)[BLOCK_SIZE] = (const unsigned char (*)[BLOCK_SIZE])arr;
-    const bool seeded = seed != NULL && seedlen > 0;
-    const int n_int = (int)n;
+    bool seeded = seed != NULL && seedlen > 0;
+    int n_int = (int)n;
     int i;
 
     // Prepare the key outside the loop if seeded
@@ -62,164 +69,21 @@ void numpy_blake3(const uint64_t* restrict arr, const size_t n, const char* rest
     #endif
     for (i = 0; i < n_int; ++i) {
         // Hash the 8-byte block
-        blake3_hash_bytes(arr8[i], BLOCK_SIZE, key, seeded, &out[i * hash_size], hash_size);
+        blake3_hash_bytes(arr8[i], BLOCK_SIZE, key, seeded, &out[i * hash_size], hash_size, false);
     }
 }
 
 // Hashes a single byte array with BLAKE3, outputs variable-length hash
 // - If a seed is provided, the keyed mode is used by setting the key (up to 32 bytes, zero-padded if shorter)
 // - Output is a uint8 array of length hash_size
-void bytes_blake3(const uint8_t* restrict data, const size_t datalen, const char* restrict seed, const size_t seedlen, uint8_t* restrict out, const size_t hash_size) {
+void bytes_blake3(const uint8_t* data, size_t datalen, const char* seed, size_t seedlen, uint8_t* out, size_t hash_size) {
     // Input: byte array; each byte is hashed as a single byte block
-    const bool seeded = seed != NULL && seedlen > 0;
-    const uint8_t *final_data = data;
-    size_t final_len = datalen;
-    int i;
+    bool seeded = seed != NULL && seedlen > 0;
 
     // Prepare the key if seeded
     uint8_t key[BLAKE3_KEY_LEN] = {0};
     prepare_blake3_key(seeded, seed, seedlen, key);
 
-    #ifdef _OPENMP
-    // =================================================================================================
-    // NOTE: The following parallel tree hashing implementation is NOT a faithful reproduction of the
-    // official BLAKE3 specification. This is due to the fact that the official BLAKE3 C library does
-    // not expose low-level APIs for direct manipulation of chunk counters, flags (CHUNK_START,
-    // CHUNK_END, PARENT, ROOT), or for initialising a hasher with an arbitrary chaining value and flags.
-    // As such, it is not possible to implement a fully compliant manual tree hash using only the public API.
-    //
-    // This manual construction parallelises hashing by chunking the input and reducing chaining values (CVs)
-    // in a binary tree fashion, similar to the official implementation. However, the following aspects of the
-    // BLAKE3 tree hashing algorithm are not adhered to here:
-    //
-    // 1. Domain Separation for Chunks:
-    //    - Each chunk is hashed as an independent message using the standard BLAKE3 hash function.
-    //    - The official BLAKE3 specification requires that each chunk be processed with a specific
-    //      chunk counter and appropriate flags (CHUNK_START, CHUNK_END) to ensure domain separation
-    //      and correct tree structure. This implementation does NOT set these parameters, and thus
-    //      the chunk hashes do not match those produced by the reference implementation.
-    //
-    // 2. Parent Node Compression:
-    //    - Parent nodes in the reduction tree are formed by concatenating two child CVs and hashing
-    //      them as a regular message. The BLAKE3 specification requires that parent nodes be
-    //      compressed using a dedicated parent node compression function, with the PARENT flag set.
-    //      This implementation does NOT use the required parent node compression logic or flags.
-    //
-    // 3. Root Finalisation and Output:
-    //    - The final root CV is re-hashed as a message to produce the output. In the BLAKE3
-    //      specification, the root CV should be used to initialise the hasher's internal state,
-    //      with the ROOT flag set, and the output should be generated using the XOF mechanism.
-    //      This implementation does NOT follow this procedure, so the output will not match the
-    //      official BLAKE3 output for the same input.
-    // =================================================================================================
-
-    // Attempt to chunk and parallelise with OpenMP to use multiple CPU cores
-
-    // Final chaining value (CV) for the output hash
-    uint8_t final_cv[BLAKE3_OUT_LEN];
-
-    // Calculate the number of chunks based on the input data length
-    const size_t num_chunks = (datalen + CHUNK_SIZE - 1) / CHUNK_SIZE;
-
-    // Define a structure to hold the chaining values (CVs) for each chunk
-    typedef struct {
-        uint8_t cv[BLAKE3_OUT_LEN];
-        uint64_t chunk_index;
-        // size_t num_blocks;
-    } cv_node_t;
-    cv_node_t* cvs = NULL;
-    if (num_chunks > 1) {
-        cvs = (cv_node_t*)malloc(num_chunks * sizeof(cv_node_t));
-    }
-
-    // Use parallel tree hashing for large inputs, fallback to serial for small or allocation failure
-    if (datalen >= MIN_PARALLEL_SIZE && num_chunks > 1 && cvs != NULL) {
-        // Parallel tree hashing path
-
-        // Estimate the CVs for each chunk
-        // WARNING: This chunk is hashed as a standalone message, without setting the required
-        // chunk counter or CHUNK_START/CHUNK_END flags as per the BLAKE3 specification.
-        // As a result, the CVs produced here do not match those of the official BLAKE3 tree.
-        #pragma omp parallel for schedule(static)
-        for (i = 0; i < (int)num_chunks; ++i) {
-            // Calculate the offset and length for this chunk
-            const size_t offset = (size_t)i * CHUNK_SIZE;
-            const size_t end = MIN(offset + CHUNK_SIZE, datalen);
-            const size_t len = end - offset;
-            cv_node_t *const out_node = &cvs[i];
-
-            // Hash the chunk
-            blake3_hash_bytes(data + offset, len, key, seeded, out_node->cv, BLAKE3_OUT_LEN);
-
-            // Set the chunk index and number of blocks
-            out_node->chunk_index = i;
-            // out_node->num_blocks = 1;
-        }
-
-        // Two buffers (ping-pong buffers) are required here to ensure that each reduction round
-        // reads from one buffer and writes to the other.
-        cv_node_t* next_cvs = (cv_node_t*)malloc(num_chunks * sizeof(cv_node_t));
-        if (next_cvs) {
-            // WARNING: This parent node is formed by hashing the concatenated child CVs
-            // as a regular message. The BLAKE3 specification requires a dedicated parent
-            // node compression with the PARENT flag, which is NOT performed here.
-            // Perform tree reduction to combine CVs
-            cv_node_t* read_buf = cvs;
-            cv_node_t* write_buf = next_cvs;
-            size_t num_nodes = num_chunks;
-            while (num_nodes > 1) {
-                const size_t new_nodes = (num_nodes + 1) / 2;
-                #pragma omp parallel for schedule(static)
-                for (i = 0; i < (int)new_nodes; ++i) {
-                    // For each node, combine the left and right children
-                    const size_t left_index = 2 * (size_t)i;
-                    if (left_index >= num_nodes) continue;  // Ensure we do not read out of bounds
-                    const size_t right_index = left_index + 1;
-                    const cv_node_t *const left_node = &read_buf[left_index];
-                    cv_node_t *const out_node = &write_buf[i];
-
-                    if (right_index < num_nodes) {
-                        // Merge left/right children
-                        const cv_node_t *const right_node = &read_buf[right_index];
-
-                        // Create a block of BLAKE3_OUT_DOUBLE_LEN bytes from two CVs
-                        uint8_t block[BLAKE3_OUT_DOUBLE_LEN];
-                        memcpy(block, left_node->cv, BLAKE3_OUT_LEN);
-                        memcpy(block + BLAKE3_OUT_LEN, right_node->cv, BLAKE3_OUT_LEN);
-
-                        // Hash the combined block
-                        blake3_hash_bytes(block, BLAKE3_OUT_DOUBLE_LEN, key, seeded, out_node->cv, BLAKE3_OUT_LEN);
-
-                        // Set the chunk index and number of blocks
-                        out_node->chunk_index = left_node->chunk_index;
-                        // out_node->num_blocks = left_node->num_blocks + right_node->num_blocks;
-                    } else {
-                        // Odd node: promote as-is
-                        memcpy(out_node->cv, left_node->cv, BLAKE3_OUT_LEN);
-                        out_node->chunk_index = left_node->chunk_index;
-                        // out_node->num_blocks = left_node->num_blocks;
-                    }
-                }
-                // Swap buffers for the next iteration
-                cv_node_t* tmp = read_buf;
-                read_buf = write_buf;
-                write_buf = tmp;
-                num_nodes = new_nodes;
-            }
-
-            // Set final_data before freeing any buffer
-            // WARNING: The final root CV is re-hashed as a message to produce the output.
-            // The BLAKE3 specification requires initialising the hasher with the root CV and the ROOT flag set,
-            // then generating the output using the XOF mechanism. This implementation does NOT follow this procedure.
-            memcpy(final_cv, read_buf[0].cv, BLAKE3_OUT_LEN);
-            final_data = final_cv;
-            final_len = BLAKE3_OUT_LEN;
-        }
-        free(next_cvs);
-    }
-    free(cvs);
-    #endif
-
-    // Finalise hash and produce an output of variable length
-    blake3_hash_bytes(final_data, final_len, key, seeded, out, hash_size);
+    // Hash the byte array
+    blake3_hash_bytes(data, datalen, key, seeded, out, hash_size, true);
 }

--- a/nphash/_npblake3.h
+++ b/nphash/_npblake3.h
@@ -1,0 +1,11 @@
+#ifndef _NPBLAKE3_H
+#define _NPBLAKE3_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+void numpy_blake3(const uint64_t* arr, size_t n, const char* seed, size_t seedlen, uint8_t* out, size_t hash_size);
+void bytes_blake3(const uint8_t* data, size_t datalen, const char* seed, size_t seedlen, uint8_t* out, size_t hash_size);
+
+#endif // _NPBLAKE3_H
+

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -246,15 +246,6 @@ def main() -> None:
                 include_dirs.append(prefix / "include")
                 library_dirs.append(prefix / "lib")
                 break
-
-        # Add vcpkg TBB include path if it exists
-        vcpkg_dir = Path(__file__).parent.parent / "vcpkg" / "installed" / "x64-windows"
-        vcpkg_tbb_include = vcpkg_dir / "include"
-        if vcpkg_tbb_include.exists():
-            include_dirs.append(vcpkg_tbb_include.resolve())
-        vcpkg_tbb_lib = vcpkg_dir / "lib"
-        if vcpkg_tbb_lib.exists():
-            library_dirs.append(vcpkg_tbb_lib.resolve())
     else:
         raise RuntimeError("Unsupported platform")
 

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -1,7 +1,7 @@
 """Build script for the nphash CFFI extension.
 
 This script uses cffi to compile the _npblake2bffi, _npblake3ffi and _npsha256ffi C extensions that provide fast, parallelised
-BLAKE2b and SHA-256 based hashing functions for NumPy arrays. The C implementations leverage OpenMP for
+BLAKE2b, BLAKE3 and SHA-256 based hashing functions for NumPy arrays. The C implementations leverage OpenMP for
 multithreading and OpenSSL for cryptographic hashing.
 
 Usage:

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -220,7 +220,7 @@ def main() -> None:
         # For MSVC: /openmp, for MinGW: -fopenmp
         if "gcc" in compiler.lower():
             libraries_c = ["libssl", "libcrypto", "gomp"]
-            libraries_cpp = ["tbb", "stdc++", "gomp"]
+            libraries_cpp = ["tbb12", "stdc++", "gomp"]
             extra_compile_args = [
                 "-std=c99",
                 "-fopenmp",
@@ -233,7 +233,7 @@ def main() -> None:
         else:
             # MSVC
             libraries_c = ["libssl", "libcrypto"]
-            libraries_cpp = ["tbb"]
+            libraries_cpp = ["tbb12"]
             extra_compile_args = ["/openmp", "-O2"]
         # Check all possible OpenSSL install locations
         for prefix in [
@@ -246,6 +246,15 @@ def main() -> None:
                 include_dirs.append(prefix / "include")
                 library_dirs.append(prefix / "lib")
                 break
+
+        # Add vcpkg TBB include path if it exists
+        vcpkg_dir = Path(__file__).parent.parent / "vcpkg" / "installed" / "x64-windows"
+        vcpkg_tbb_include = vcpkg_dir / "include"
+        if vcpkg_tbb_include.exists():
+            include_dirs.append(vcpkg_tbb_include.resolve())
+        vcpkg_tbb_lib = vcpkg_dir / "lib"
+        if vcpkg_tbb_lib.exists():
+            library_dirs.append(vcpkg_tbb_lib.resolve())
     else:
         raise RuntimeError("Unsupported platform")
 

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -277,18 +277,18 @@ def main() -> None:
     c_source_sha256 = _get_c_source(parent_dir / "_npsha256.c")
 
     # Prepare compile args for BLAKE3: do NOT specify -std=c99 or -std=c++11 (let compiler choose defaults)
-    blake3_compile_args = [
-        arg for arg in extra_compile_args if not arg.startswith("-std=")
-    ]
-    blake3_compile_args.extend([
-        "-DBLAKE3_USE_TBB",
-        "-DBLAKE3_NO_SSE2",
-        "-DBLAKE3_NO_SSE41",
-        "-DBLAKE3_NO_AVX2",
-        "-DBLAKE3_NO_AVX512",
-        "-DBLAKE3_USE_NEON=0",
-        "-DTBB_USE_EXCEPTIONS=0",
-    ])
+    blake3_compile_args = [arg for arg in extra_compile_args if not arg.startswith("-std=")]
+    blake3_compile_args.extend(
+        [
+            "-DBLAKE3_USE_TBB",
+            "-DBLAKE3_NO_SSE2",
+            "-DBLAKE3_NO_SSE41",
+            "-DBLAKE3_NO_AVX2",
+            "-DBLAKE3_NO_AVX512",
+            "-DBLAKE3_USE_NEON=0",
+            "-DTBB_USE_EXCEPTIONS=0",
+        ]
+    )
 
     # Add extension build
     ffibuilder_blake2b.set_source(
@@ -329,7 +329,11 @@ def main() -> None:
     )
 
     _print_build_summary(
-        libraries_c + libraries_cpp, extra_compile_args, extra_link_args, include_paths, library_paths
+        libraries_c + libraries_cpp,
+        extra_compile_args,
+        extra_link_args,
+        include_paths,
+        library_paths,
     )
     ffibuilder_blake2b.compile(verbose=True)
     ffibuilder_blake3.compile(verbose=True)

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -278,6 +278,7 @@ def main() -> None:
     c_source_sha256 = _get_c_source(parent_dir / "_npsha256.c")
 
     # Prepare compile args for BLAKE3: do NOT specify -std=c99 or -std=c++11 (let compiler choose defaults)
+    # This avoids errors related to C++11 features in C code.
     blake3_compile_args = [arg for arg in extra_compile_args if not arg.startswith("-std=")]
     blake3_compile_args.extend(
         [

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -271,15 +271,18 @@ def main() -> None:
     c_source_blake2b = _get_c_source(parent_dir / "_npblake2b.c")
     c_source_sha256 = _get_c_source(parent_dir / "_npsha256.c")
 
-    # Prepare compile args for BLAKE3: remove '-std=c99', add '-std=c++11' and '-DTBB_USE_EXCEPTIONS=0'
-    blake3_compile_args = [arg for arg in extra_compile_args if arg != '-std=c99']
-    blake3_compile_args += ['-std=c++11', '-DTBB_USE_EXCEPTIONS=0', '-DBLAKE3_USE_TBB']
+    # Prepare compile args for BLAKE3: do NOT specify -std=c99 or -std=c++11 (let compiler choose defaults)
+    blake3_compile_args = [
+        arg for arg in extra_compile_args if not arg.startswith('-std=')
+    ]
     blake3_compile_args += [
+        '-DBLAKE3_USE_TBB',
         '-DBLAKE3_NO_SSE2',
         '-DBLAKE3_NO_SSE41',
         '-DBLAKE3_NO_AVX2',
         '-DBLAKE3_NO_AVX512',
         '-DBLAKE3_USE_NEON=0',
+        '-DTBB_USE_EXCEPTIONS=0',
     ]
 
     # Use CFFI to build the BLAKE3 extension from sources directly, WITHOUT any SIMD/acceleration files

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -290,7 +290,17 @@ def main() -> None:
         "-DTBB_USE_EXCEPTIONS=0",
     ])
 
-    # Use CFFI to build the BLAKE3 extension from sources directly
+    # Add extension build
+    ffibuilder_blake2b.set_source(
+        "_npblake2bffi",
+        c_source_blake2b,
+        libraries=libraries_c,
+        extra_compile_args=extra_compile_args,
+        extra_link_args=extra_link_args,
+        include_dirs=include_paths,
+        library_dirs=library_paths,
+    )
+
     ffibuilder_blake3.set_source(
         "_npblake3ffi",
         '#include "_npblake3.h"\n',
@@ -303,17 +313,6 @@ def main() -> None:
         ],
         libraries=libraries_cpp,
         extra_compile_args=blake3_compile_args,
-        extra_link_args=extra_link_args,
-        include_dirs=include_paths,
-        library_dirs=library_paths,
-    )
-
-    # Add extension build
-    ffibuilder_blake2b.set_source(
-        "_npblake2bffi",
-        c_source_blake2b,
-        libraries=libraries_c,
-        extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,
         include_dirs=include_paths,
         library_dirs=library_paths,

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -10,6 +10,7 @@ Usage:
 This will generate the _npblake2bffi, _npblake3ffi and _npsha256ffi extension modules, which can be imported from Python code.
 """
 
+import os
 import platform
 import shlex
 import shutil
@@ -18,7 +19,6 @@ import sys
 import sysconfig
 import tempfile
 import urllib.request
-import os
 from pathlib import Path
 
 from cffi import FFI
@@ -308,10 +308,7 @@ def main() -> None:
         sources=[
             # Use relative paths to ensure we don't output absolute paths in the generated CFFI files
             os.path.relpath(nphash_dir / "_npblake3.c", nphash_dir),
-            os.path.relpath(blake3_dir / "blake3.c", nphash_dir),
-            os.path.relpath(blake3_dir / "blake3_dispatch.c", nphash_dir),
-            os.path.relpath(blake3_dir / "blake3_portable.c", nphash_dir),
-            os.path.relpath(blake3_dir / "blake3_tbb.cpp", nphash_dir),
+            *[os.path.relpath(f, nphash_dir) for f in sorted(blake3_dir.glob("*.c*"))],
         ],
         libraries=libraries_cpp,
         extra_compile_args=blake3_compile_args,


### PR DESCRIPTION
We remove the custom implementation of tree hashing and instead use the threaded official `blake3_hasher_update_tbb` API. This is faster on some platforms but slower in others. I'll benchmark more precisely later.

Benchmark on MacOS (faster than before):
```
The 'encode' step took 1.949 seconds.
The 'decode' step took 1.616 seconds.
```

Benchmark on Linux (slower than before):
```
The 'encode' step took 6.624 seconds.
The 'decode' step took 6.065 seconds.
```

There are pros and cons to this change:
- Pros:
  - More secure. We use the official implementation.
  - Less C code to maintain.
- Cons:
  - Potentially slower in some platforms TBD
  - Requires [TBB](https://uxlfoundation.github.io/oneTBB/) and building this on Windows is a pain. Moreover we mix C and C++ files which leads to pain on MacOS. To resolve we had to do some hacks on the build.py script and on the CI yamls but it worked.

I think we should merge this, in the grounds of security and maintainability.