### PR TITLE
Add a minimum threshold for blake3 parallelisation

### DIFF
--- a/nphash/_npblake3.c
+++ b/nphash/_npblake3.c
@@ -11,6 +11,7 @@
 #endif
 
 #define BLOCK_SIZE 8  // Each input element is a uint64 block
+#define MIN_PARALLEL_LEN (2 * BLAKE3_CHUNK_LEN) // Minimum data length to enable parallel tree hashing
 
 // Inline helper to prepare a BLAKE3 key from a seed (up to 32 bytes, zero-padded if shorter)
 static inline void prepare_blake3_key(bool seeded, const char* seed, size_t seedlen, uint8_t key[BLAKE3_KEY_LEN]) {
@@ -84,5 +85,5 @@ void bytes_blake3(const uint8_t* data, size_t datalen, const char* seed, size_t 
     prepare_blake3_key(seeded, seed, seedlen, key);
 
     // Hash the byte array
-    blake3_hash_bytes(data, datalen, key, seeded, out, hash_size, true);
+    blake3_hash_bytes(data, datalen, key, seeded, out, hash_size, datalen >= MIN_PARALLEL_LEN);
 }


### PR DESCRIPTION
Parallelise BLAKE3 only if there are sufficient data (set to 2048 bytes) to justify the overhead. BLAKE3's [readme](https://github.com/BLAKE3-team/BLAKE3/blob/acf7a54fe2c0d616127fb5bc8e68156c173975cf/c/README.md?plain=1#L186) suggests 128KiB but notes this depends on hardware.