### PR TITLE
Blake3 with Hardware acceleration

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set benchmark sizes
         id: benchvars
         run: |
-          echo "SIZES=25 100 250" >> $GITHUB_ENV
+          echo "SIZES=25 100 500" >> $GITHUB_ENV
 
       - name: Install system dependencies and build C modules
         run: |

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ If you want to use fast vectorised key stream functions, install with both `nump
 
 ## 🚦 Benchmarks: VernamVeil vs AES-256-CBC
 
-VernamVeil prioritises educational value and cryptographic experimentation over raw speed. As expected, it is about 1.9x slower than highly optimised, hardware-accelerated cyphers like AES-256-CBC. This is due to its Python implementation and focus on flexibility rather than production-grade speed or safety. The following benchmarks compare VernamVeil (using its fastest configuration: NumPy vectorisation, C extension enabled, with `generate_keyed_hash_fx` and `blake3` hashing) to OpenSSL's AES-256-CBC on the same Ubuntu Linux machine.
+VernamVeil prioritises educational value and cryptographic experimentation over raw speed. As expected, it is about 70% slower than highly optimised, hardware-accelerated cyphers like AES-256-CBC. This is due to its Python implementation and focus on flexibility rather than production-grade speed or safety. The following benchmarks compare VernamVeil (using its fastest configuration: NumPy vectorisation, C extension enabled, with `generate_keyed_hash_fx` and `blake3` hashing) to OpenSSL's AES-256-CBC on the same Ubuntu Linux machine.
 
 ### ‍💻 Benchmark Setup
 
@@ -496,13 +496,13 @@ openssl rand -hex 16 > iv.hex
 ```bash
 vernamveil encode --infile /tmp/original.bin --outfile /tmp/output.enc --fx-file fx.py --seed-file seed.bin --buffer-size 134217728 --chunk-size 1048576 --delimiter-size 64 --padding-range 100 200 --decoy-ratio 0.01 --hash-name blake3 --verbosity info
 ```
-_Time: 5.728s_
+_Time: 5.028s_
 
 **Decoding:**
 ```bash
 vernamveil decode --infile /tmp/output.enc --outfile /tmp/output.dec --fx-file fx.py --seed-file seed.bin --buffer-size 136349200 --chunk-size 1048576 --delimiter-size 64 --padding-range 100 200 --decoy-ratio 0.01 --hash-name blake3 --verbosity info
 ```
-_Time: 4.822s_
+_Time: 4.501s_
 
 ### 🐇 AES-256-CBC (OpenSSL)
 
@@ -522,7 +522,7 @@ _Time: 2.636s_
 
 | Algorithm    | Encode Time | Decode Time |
 |--------------|-------------|-------------|
-| VernamVeil   | 5.7 s       | 4.8 s       |
+| VernamVeil   | 5.0 s       | 4.5 s       |
 | AES-256-CBC  | 3.0 s       | 2.6 s       |
 
 ---

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
-import urllib.request
 from distutils.command.build_ext import build_ext as _build_ext
 from pathlib import Path
 
@@ -131,9 +130,9 @@ def _ensure_blake3_sources(blake3_dir: Path, version: str) -> None:
     tmpdir = tempfile.mkdtemp()
     repo_url = "https://github.com/BLAKE3-team/BLAKE3.git"
     print(f"Cloning BLAKE3 {version} from {repo_url} to {tmpdir} ...")
-    subprocess.run([
-        "git", "clone", "--depth", "1", "--branch", version, repo_url, tmpdir
-    ], check=True)
+    subprocess.run(
+        ["git", "clone", "--depth", "1", "--branch", version, repo_url, tmpdir], check=True
+    )
     src_dir = Path(tmpdir) / "c"
     blake3_dir.mkdir(parents=True, exist_ok=True)
     for f in src_dir.iterdir():
@@ -397,10 +396,12 @@ def main() -> None:
     blake3_compile_args.extend(blake3_simd_flags)
     blake3_compile_args.extend(blake3_simd_defines)
     if tbb_enabled:
-        blake3_compile_args.extend([
-            "-DBLAKE3_USE_TBB",
-            "-DTBB_USE_EXCEPTIONS=0",
-        ])
+        blake3_compile_args.extend(
+            [
+                "-DBLAKE3_USE_TBB",
+                "-DTBB_USE_EXCEPTIONS=0",
+            ]
+        )
 
     # --- BLAKE3 SIMD object compilation and source selection ---
     blake3_sources = [os.path.relpath(nphash_dir / "_npblake3.c", nphash_dir)]
@@ -426,7 +427,9 @@ def main() -> None:
             if src.exists():
                 # For AVX512, use both -mavx512f and -mavx512vl if available
                 if fname == "blake3_avx512.c":
-                    compile_cmd = [compiler, "-c", str(src)] + avx512_flags + ["-O3", "-o", str(obj)]
+                    compile_cmd = (
+                        [compiler, "-c", str(src)] + avx512_flags + ["-O3", "-o", str(obj)]
+                    )
                 else:
                     compile_cmd = [compiler, "-c", str(src), flag, "-O3", "-o", str(obj)]
                 print(f"Compiling {src} with {compile_cmd[3:-2]} -> {obj}")
@@ -440,7 +443,9 @@ def main() -> None:
             blake3_sources.append(os.path.relpath(f, nphash_dir))
 
     # Remove SIMD flags from compile args for the main extension
-    blake3_compile_args_main = [arg for arg in blake3_compile_args if arg not in [flag for _, flag in simd_files_flags]]
+    blake3_compile_args_main = [
+        arg for arg in blake3_compile_args if arg not in [flag for _, flag in simd_files_flags]
+    ]
 
     ffibuilder_blake3.set_source(
         "_npblake3ffi",

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -127,18 +127,18 @@ def _ensure_blake3_sources(blake3_dir: Path, version: str) -> None:
     if blake3_dir.exists() and any(blake3_dir.iterdir()):
         print(f"BLAKE3 sources already present at {blake3_dir.resolve()}. Skipping clone.")
         return
-    tmpdir = tempfile.mkdtemp()
-    repo_url = "https://github.com/BLAKE3-team/BLAKE3.git"
-    print(f"Cloning BLAKE3 {version} from {repo_url} to {tmpdir} ...")
-    subprocess.run(
-        ["git", "clone", "--depth", "1", "--branch", version, repo_url, tmpdir], check=True
-    )
-    src_dir = Path(tmpdir) / "c"
-    blake3_dir.mkdir(parents=True, exist_ok=True)
-    for f in src_dir.iterdir():
-        if f.is_file():
-            shutil.copy2(f, blake3_dir / f.name)
-    print(f"Copied BLAKE3 C sources to {blake3_dir.resolve()}")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_url = "https://github.com/BLAKE3-team/BLAKE3.git"
+        print(f"Cloning BLAKE3 {version} from {repo_url} to {tmpdir} ...")
+        subprocess.run(
+            ["git", "clone", "--depth", "1", "--branch", version, repo_url, tmpdir], check=True
+        )
+        src_dir = Path(tmpdir) / "c"
+        blake3_dir.mkdir(parents=True, exist_ok=True)
+        for f in src_dir.iterdir():
+            if f.is_file():
+                shutil.copy2(f, blake3_dir / f.name)
+        print(f"Copied BLAKE3 C sources to {blake3_dir.resolve()}")
 
 
 class _build_ext_with_cpp11(_build_ext):

--- a/nphash/build.py
+++ b/nphash/build.py
@@ -384,6 +384,13 @@ def main() -> None:
     else:
         blake3_simd_defines.append("-DBLAKE3_USE_NEON=0")
 
+    # Check for AVX512VL support if AVX512F is supported
+    avx512_flags = []
+    if "-mavx512f" in blake3_simd_flags:
+        avx512_flags.append("-mavx512f")
+        if _supports_flag(compiler, "-mavx512vl"):
+            avx512_flags.append("-mavx512vl")
+
     # Prepare compile args for BLAKE3: do NOT specify -std=c99 or -std=c++11 (let compiler choose defaults)
     # This avoids errors related to C++11 features in C code.
     blake3_compile_args = [arg for arg in extra_compile_args if not arg.startswith("-std=")]
@@ -410,13 +417,6 @@ def main() -> None:
         ("blake3_avx512.c", "-mavx512f"),
         ("blake3_neon.c", "-mfpu=neon"),
     ]
-
-    # Check for AVX512VL support if AVX512F is supported
-    avx512_flags = []
-    if "-mavx512f" in blake3_simd_flags:
-        avx512_flags.append("-mavx512f")
-        if _supports_flag(compiler, "-mavx512vl"):
-            avx512_flags.append("-mavx512vl")
 
     simd_objects = []
     for fname, flag in simd_files_flags:


### PR DESCRIPTION
Adding support to all -msse2, -msse4.1, -mavx2, -mavx512f, -mavx512vl and -mfpu=neon, for hardware acceleration.

Linux Benchmarks:
```
The 'encode' step took 5.028 seconds.
The 'decode' step took 4.501 seconds.
```