### PR TITLE
Memory Alignment Check

### DIFF
--- a/nphash/_npblake3.c
+++ b/nphash/_npblake3.c
@@ -16,7 +16,7 @@
 #define MIN_PARALLEL_LEN (2 * BLAKE3_CHUNK_LEN) // Minimum data length to enable parallel tree hashing
 
 // Platform-specific alignment for SIMD acceleration
-#if defined(__AVX512F__)
+#if defined(__AVX512F__) || defined(__AVX512VL__)
     #define BLAKE3_ALIGNMENT 64
 #elif defined(__AVX2__)
     #define BLAKE3_ALIGNMENT 32


### PR DESCRIPTION
Linux requires alignment (as seen by debug `[bytes_blake3] Alignment required` messages [here](https://github.com/datumbox/VernamVeil/actions/runs/15402851693/job/43339331461)) but not macOS.

Benchmarks show that aligning is 30% slower. Closing.