### PR TITLE
Preallocated Obfuscation

### DIFF
--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -301,7 +301,7 @@ class VernamVeil(_Cypher):
         random_size = sum(pad_lens) + decoy_count * chunk_size
         random_bytes = memoryview(secrets.token_bytes(random_size))
 
-        # Calculate thhe exact size from the delimiters, message, and random bytes
+        # Calculate the exact size from the delimiters, message, and random bytes
         exact_size = pad_count * self._delimiter_size + random_size + message_len
 
         # Build the noisy message by combining fake and shuffled real chunks


### PR DESCRIPTION
All random bytes are estimated using a single call. This is marginally faster and cleaner. This approach recovers the speed loss of obfuscation from #19. We compare the before an after using the same micro-benchmark script as #19:

## No preallocation (original)
```
Sample 1: mean 0.025189 s
Sample 2: mean 0.024618 s
Sample 3: mean 0.024411 s
Sample 4: mean 0.024424 s
Sample 5: mean 0.024435 s

Median of sample means over 5 samples: 0.024435s
```

# Preallocation
```
Sample 1: mean 0.018602 s
Sample 2: mean 0.020114 s
Sample 3: mean 0.018787 s
Sample 4: mean 0.019165 s
Sample 5: mean 0.020002 s

Median of sample means over 5 samples: 0.019165s
```