### PR TITLE
Reduce hashes required for shuffling

### DIFF
--- a/vernamveil/_hash_utils.py
+++ b/vernamveil/_hash_utils.py
@@ -147,9 +147,11 @@ def fold_bytes_to_uint64(
         ValueError: If the input array is not 2D or has less than 8 columns.
         ValueError: If fold_type is not 'full' or 'view'.
     """
+    if hashes.ndim != 2:
+        raise ValueError("The input must be a 2D array.")
     cols = hashes.shape[1]
-    if hashes.ndim != 2 or cols < 8:
-        raise ValueError("Input must be a 2D array with at least 8 columns per row.")
+    if cols < 8:
+        raise ValueError("The input must have at least 8 columns per row.")
     if fold_type == "view":
         # Create a view of the first 8 bytes as uint64 (big-endian)
         if cols > 8:

--- a/vernamveil/_hash_utils.py
+++ b/vernamveil/_hash_utils.py
@@ -147,11 +147,15 @@ def fold_bytes_to_uint64(
         ValueError: If the input array is not 2D or has less than 8 columns.
         ValueError: If fold_type is not 'full' or 'view'.
     """
-    if hashes.ndim != 2 or hashes.shape[1] < 8:
+    cols = hashes.shape[1]
+    if hashes.ndim != 2 or cols < 8:
         raise ValueError("Input must be a 2D array with at least 8 columns per row.")
     if fold_type == "view":
         # Create a view of the first 8 bytes as uint64 (big-endian)
-        return hashes[:, :8].view(np.uint64).reshape(-1).byteswap()
+        if cols > 8:
+            # If there are more than 8 columns, we only take the first 8
+            hashes = hashes[:, :8]
+        return hashes.view(np.uint64).reshape(-1).byteswap()
     elif fold_type == "full":
         # Compute the shifts for each byte position (big-endian)
         shifts = np.arange((hashes.shape[1] - 1) * 8, -1, -8, dtype=np.uint64)

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -190,7 +190,7 @@ class VernamVeil(_Cypher):
         # Create a list with all positions
         positions = list(range(total_count))
 
-        hashes: Sequence[int]
+        random_ints: Sequence[int]
         if self._fx.vectorise:
             # Vectorised: generate all hashes at once
 
@@ -210,11 +210,11 @@ class VernamVeil(_Cypher):
             truncated_bytes = raw_bytes.ravel()[:num_bytes_needed].reshape(num_uint64_needed, 8)
 
             # Fold these bytes into an array of uint64s.
-            hashes = fold_bytes_to_uint64(truncated_bytes)
+            random_ints = fold_bytes_to_uint64(truncated_bytes)
         else:
             # Standard: generate hashes one by one
             byteorder: Literal["little", "big"] = "big"
-            hashes = [
+            random_ints = [
                 int.from_bytes(self._hash(seed, [i.to_bytes(8, byteorder)]), byteorder)
                 for i in range(1, total_count)
             ]
@@ -222,7 +222,7 @@ class VernamVeil(_Cypher):
         # Shuffle deterministically based on the hashed seed
         for i in range(total_count - 1, 0, -1):
             # Create a random number between 0 and i
-            j = hashes[i - 1] % (i + 1)
+            j = random_ints[i - 1] % (i + 1)
 
             # Swap elements at positions i and j
             positions[i], positions[j] = positions[j], positions[i]

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -201,7 +201,7 @@ class VernamVeil(_Cypher):
             num_raw_hash_outputs = math.ceil(num_bytes_needed / self._HASH_LENGTH)
 
             # Generate input indices for these raw hash outputs.
-            i_arr = np.arange(1, num_raw_hash_outputs + 1, dtype=np.uint64)
+            i_arr = np.arange(num_raw_hash_outputs, dtype=np.uint64)
 
             # Get the raw bytes from hashing these indices.
             raw_bytes = hash_numpy(i_arr, seed, self._hash_name)

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -204,7 +204,7 @@ class VernamVeil(_Cypher):
             i_arr = np.arange(num_raw_hash_outputs, dtype=np.uint64)
 
             # Get the raw bytes from hashing these indices.
-            raw_bytes = hash_numpy(i_arr, seed, self._hash_name)
+            raw_bytes = hash_numpy(i_arr, seed, self._hash_name, self._HASH_LENGTH)
 
             # Truncate the raw bytes to the exact total number of bytes needed for the uint64s.
             truncated_bytes = raw_bytes.ravel()[:num_bytes_needed].reshape(num_uint64_needed, 8)


### PR DESCRIPTION
We reduce the amount of hash operations required for shuffling. We get a 65% improvement on the `_determine_shuffled_indices()` method.

```python
import secrets
import timeit
from statistics import median

from vernamveil import VernamVeil, generate_default_fx

fx = generate_default_fx(vectorise=True)
cypher = VernamVeil(fx, chunk_size=1024, delimiter_size=8, padding_range=(5, 15), decoy_ratio=0.2)

seed = secrets.token_bytes(64)
real_count = 1000
decoy_count = int(0.2 * real_count)
total_count = real_count + decoy_count


def run_determine_shuffled_indices():
    cypher._determine_shuffled_indices(seed, real_count, total_count)


# Warm-up
for _ in range(10):
    run_determine_shuffled_indices()

sample_means = []
num_samples = 5
runs_per_sample = 10000

for sample in range(num_samples):
    t = timeit.repeat(
        stmt="run()",
        setup="from __main__ import run_determine_shuffled_indices as run",
        repeat=1,
        number=runs_per_sample,
    )
    mean_time = t[0] / runs_per_sample
    sample_means.append(mean_time)
    print(f"Sample {sample+1}: mean {mean_time:.8f} s")

final_median = median(sample_means)
print(f"\nMedian of sample means over {num_samples} samples: {final_median:.8f}s")
```

Before:
```
Sample 1: mean 0.00140672 s
Sample 2: mean 0.00155961 s
Sample 3: mean 0.00143652 s
Sample 4: mean 0.00208728 s
Sample 5: mean 0.00137725 s

Median of sample means over 5 samples: 0.00143652s
```

After:
```
Sample 1: mean 0.00046009 s
Sample 2: mean 0.00051345 s
Sample 3: mean 0.00050715 s
Sample 4: mean 0.00053217 s
Sample 5: mean 0.00054147 s

Median of sample means over 5 samples: 0.00051345s
```