### PR TITLE
Experimental Knuth-Morris-Pratt string search

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
           python -m pip install .[dev,numpy,cffi]
           cd nphash
           python build.py
-          ls -lh _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*
+          ls -lh _kmpffi.* _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*
           cd ..
           python -m pip install .
         shell: bash

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -32,12 +32,11 @@ jobs:
       - name: Install system dependencies and build C modules
         run: |
           sudo apt-get update && sudo apt-get install -y build-essential g++ libssl-dev libtbb-dev python3-dev
-          python -m pip install .[dev,numpy,cffi]
+          python -m pip install -e .[dev,numpy,cffi]
           cd nphash
           python build.py
           ls -lh _kmpffi.* _npblake2bffi.* _npblake3ffi.* _npsha256ffi.*
-          cd ..
-          python -m pip install .
+          python -c "from vernamveil._types import _HAS_C_MODULE; assert _HAS_C_MODULE; print('The C module is importable')"
         shell: bash
 
       - name: Create benchmark data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,6 @@ jobs:
       - name: Assert C module existence and importability
         if: matrix.build-steps != ''
         run: | 
-          ls -lh nphash/_npblake2bffi.*.* nphash/_npblake3ffi.*.* nphash/_npsha256ffi.*.*
+          ls -lh nphash/_kmpffi.* nphash/_npblake2bffi.*.* nphash/_npblake3ffi.*.* nphash/_npsha256ffi.*.*
           python -c "from vernamveil._types import _HAS_C_MODULE; assert _HAS_C_MODULE; print('The C module is importable')"
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ build/
 dist/
 docs-html/
 nphash/*.o
-nphash/_npblake2bffi*
-nphash/_npblake3ffi*
-nphash/_npsha256ffi*
+nphash/_*ffi.*
 reports/
 third_party/

--- a/nphash/__init__.py
+++ b/nphash/__init__.py
@@ -2,6 +2,7 @@
 
 from types import ModuleType
 
+_kmpffi: ModuleType
 _npblake2bffi: ModuleType
 _npblake3ffi: ModuleType
 _npsha256ffi: ModuleType

--- a/nphash/_kmp.c
+++ b/nphash/_kmp.c
@@ -46,7 +46,7 @@ size_t* find_all_kmp(const unsigned char *text, size_t n,
     size_t j = 0; // Index for pattern[]
 
     // Initial allocation for indices. We can reallocate if more are found.
-    size_t capacity = 10;
+    size_t capacity = 1000;
     size_t *indices = (size_t *)malloc(sizeof(size_t) * capacity);
     if (indices == NULL) {
         free(lps);

--- a/nphash/_kmp.c
+++ b/nphash/_kmp.c
@@ -1,0 +1,108 @@
+#include <stdlib.h>
+#include <stddef.h>
+#include "_kmp.h"
+
+// Computes the Longest Proper Prefix which is also Suffix (LPS) array.
+// This is a standard KMP preprocessing step.
+// Marked static to limit visibility to this file.
+static void compute_lps_array_kmp(const unsigned char *pattern, size_t m, size_t *lps) {
+    size_t length = 0; // Length of the previous longest prefix suffix
+    lps[0] = 0;       // lps[0] is always 0
+    size_t i = 1;
+
+    // The loop calculates lps[i] for i = 1 to m-1
+    while (i < m) {
+        if (pattern[i] == pattern[length]) {
+            lps[i++] = ++length;
+        } else {
+            // This is tricky. Consider the example.
+            // AAACAAAA and i = 7. The idea is similar to search step.
+            if (length != 0) {
+                length = lps[length - 1];
+                // Also, note that we do not increment i here
+            } else {
+                lps[i++] = 0;
+            }
+        }
+    }
+}
+
+// Searches for all occurrences of 'pattern' in 'text' using KMP.
+// Returns a dynamically allocated array of indices, and sets count_ptr.
+// Caller must free the returned array using free_indices_kmp.
+size_t* find_all_kmp(const unsigned char *text, size_t n,
+                                const unsigned char *pattern, size_t m,
+                                size_t *count_ptr) {
+    *count_ptr = 0;
+
+    // Allocate LPS array
+    size_t *lps = (size_t *)malloc(sizeof(size_t) * m);
+    if (lps == NULL) {
+        return NULL;
+    }
+    compute_lps_array_kmp(pattern, m, lps);
+
+    size_t i = 0; // Index for text[]
+    size_t j = 0; // Index for pattern[]
+
+    // Initial allocation for indices. We can reallocate if more are found.
+    size_t capacity = 10;
+    size_t *indices = (size_t *)malloc(sizeof(size_t) * capacity);
+    if (indices == NULL) {
+        free(lps);
+        return NULL;
+    }
+
+    while (i < n) {
+        if (pattern[j] == text[i]) {
+            ++i;
+            ++j;
+        }
+
+        if (j == m) {
+            // Found pattern at index (i - j)
+            if (*count_ptr >= capacity) {
+                capacity *= 2;
+                size_t *new_indices = (size_t *)realloc(indices, sizeof(size_t) * capacity);
+                if (new_indices == NULL) {
+                    free(lps);
+                    free(indices);
+                    *count_ptr = 0; // Indicate failure
+                    return NULL;
+                }
+                indices = new_indices;
+            }
+            indices[*count_ptr] = i - j;
+            (*count_ptr)++;
+            j = lps[j - 1]; // Continue search for more occurrences
+        } else if (i < n && pattern[j] != text[i]) {
+            // Mismatch after j matches
+            // Do not match lps[0..lps[j-1]] characters, they will match anyway
+            if (j != 0) {
+                j = lps[j - 1];
+            } else {
+                ++i;
+            }
+        }
+    }
+
+    free(lps);
+
+    if (*count_ptr == 0) {
+        free(indices);
+        return NULL;
+    }
+    // Shrink to fit if desired, or leave as is for simplicity
+    // size_t *final_indices = (size_t *)realloc(indices, sizeof(size_t) * (*count_ptr));
+    // if (final_indices == NULL && *count_ptr > 0) { /* handle error, though unlikely if shrinking */ }
+    // else if (*count_ptr > 0) { indices = final_indices; }
+
+    return indices;
+}
+
+// Frees the array of indices allocated by find_all_kmp.
+void free_indices_kmp(size_t *indices_ptr) {
+    if (indices_ptr != NULL) {
+        free(indices_ptr);
+    }
+}

--- a/nphash/_kmp.h
+++ b/nphash/_kmp.h
@@ -1,0 +1,25 @@
+#ifndef NPKMP_H
+#define NPKMP_H
+
+#include <stddef.h> // For size_t
+
+// Searches for all occurrences of 'pattern' in 'text' using Knuth-Morris-Pratt.
+// Parameters:
+//   text: The text to search within.
+//   n: The length of the text.
+//   pattern: The pattern to search for.
+//   m: The length of the pattern.
+//   count_ptr: Out-parameter, will be filled with the number of occurrences found.
+// Returns:
+//   A dynamically allocated array of integers containing the 0-based starting
+//   indices of all occurrences. The caller is responsible for freeing this array
+//   using free_indices_kmp. Returns NULL if no occurrences are found,
+//   if m > n, or if memory allocation fails.
+size_t* find_all_kmp(const unsigned char *text, size_t n,
+                                   const unsigned char *pattern, size_t m,
+                                   size_t *count_ptr);
+
+// Frees the array of indices allocated by find_all_kmp.
+void free_indices_kmp(size_t *indices_ptr);
+
+#endif // NPKMP_H

--- a/vernamveil/_find.py
+++ b/vernamveil/_find.py
@@ -43,8 +43,8 @@ def find_all(haystack: bytes | bytearray, needle: bytes | bytearray | memoryview
         count = count_ptr[0]
 
         if indices_ptr is not ffi.NULL and count > 0:
-            for i in range(count):
-                result_indices.append(indices_ptr[i])
+            # convert the C array of size_t to a Python list in one go
+            result_indices = ffi.unpack(indices_ptr, count)
             _kmpffi.lib.free_indices_kmp(indices_ptr)
 
     return result_indices

--- a/vernamveil/_find.py
+++ b/vernamveil/_find.py
@@ -1,0 +1,50 @@
+from vernamveil._types import _kmpffi
+
+
+def find_all(haystack: bytes | bytearray, needle: bytes | bytearray | memoryview) -> list[int]:
+    """Finds all occurrences of pattern_bytes in text_bytes using KMP.
+
+    Args:
+        haystack (bytes or bytearray): The bytes object to search within.
+        needle (bytes or bytearray or memoryview): The bytes object to search for.
+
+    Returns:
+        list[int]: A list of 0-based starting indices of all occurrences. Returns an empty list if
+            no occurrences are found or if the pattern is empty or longer than the text.
+    """
+    result_indices: list[int] = []
+    n = len(haystack)
+    m = len(needle)
+
+    if m == 0 or n == 0 or m > n:
+        return result_indices
+
+    if _kmpffi is None:
+        # Fallback to Python implementation if C library is not available
+        look_start = 0  # Start position for searching the next needle
+        while look_start < n:
+            # Search for the next occurrence of the delimiter
+            idx = haystack.find(needle, look_start)
+            if idx == -1:
+                # No more needle found
+                break
+            # Append the found index to the result
+            result_indices.append(idx)
+            # Move the search start past the current needle
+            look_start = idx + m
+    else:
+        # Use the C extension for KMP search
+        ffi = _kmpffi.ffi
+
+        count_ptr = ffi.new("size_t *")
+        indices_ptr = _kmpffi.lib.find_all_kmp(
+            ffi.from_buffer(haystack), n, ffi.from_buffer(needle), m, count_ptr
+        )
+        count = count_ptr[0]
+
+        if indices_ptr is not ffi.NULL and count > 0:
+            for i in range(count):
+                result_indices.append(indices_ptr[i])
+            _kmpffi.lib.free_indices_kmp(indices_ptr)
+
+    return result_indices

--- a/vernamveil/_types.py
+++ b/vernamveil/_types.py
@@ -21,15 +21,17 @@ except ImportError:
 
 # C module types and imports
 _HashType: Any
+_kmpffi: Any
 _npblake2bffi: Any
 _npblake3ffi: Any
 _npsha256ffi: Any
 try:
-    from nphash import _npblake2bffi, _npblake3ffi, _npsha256ffi
+    from nphash import _kmpffi, _npblake2bffi, _npblake3ffi, _npsha256ffi
 
     _HAS_C_MODULE = True
     _HashType = Literal["blake2b", "blake3", "sha256"]
 except ImportError:
+    _kmpffi = None
     _npblake2bffi = None
     _npblake3ffi = None
     _npsha256ffi = None


### PR DESCRIPTION
It's unclear why KMP search so much slower than vanilla find but it is. 

This is 50% slower on the whole decoding and several times slower if we account for the fact that deobfuscation is actually a tiny part of the normal decoding step.
```
The 'decode' step took 6.273 seconds.
```

This PR is half-baked as it doesn't include documentation updates, tests or a pyproject integration for the module. I'm not going to implement this as it's completely nonviable as an approach.