### PR TITLE
Optimised Bytes Array: Conditional buffer based on Vectorisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ If you want to use fast vectorised key stream functions, install with both `nump
 
 ## 🚦 Benchmarks: VernamVeil vs AES-256-CBC
 
-VernamVeil prioritises educational value and cryptographic experimentation over raw speed. As expected, it is about 43-59% slower than highly optimised, hardware-accelerated cyphers like AES-256-CBC. This is due to its Python implementation and focus on flexibility rather than production-grade speed or safety. The following benchmarks compare VernamVeil (using its fastest configuration: NumPy vectorisation, C extension enabled, with `generate_keyed_hash_fx` and `blake3` hashing) to OpenSSL's AES-256-CBC on the same Ubuntu Linux machine.
+VernamVeil prioritises educational value and cryptographic experimentation over raw speed. As expected, it is about 10-27% slower than highly optimised, hardware-accelerated cyphers like AES-256-CBC. This is due to its Python implementation and focus on flexibility rather than production-grade speed or safety. The following benchmarks compare VernamVeil (using its fastest configuration: NumPy vectorisation, C extension enabled, with `generate_keyed_hash_fx` and `blake3` hashing) to OpenSSL's AES-256-CBC on the same Ubuntu Linux machine.
 
 ### ‍💻 Benchmark Setup
 
@@ -498,13 +498,13 @@ openssl rand -hex 16 > iv.hex
 ```bash
 vernamveil encode --infile /tmp/original.bin --outfile /tmp/output.enc --fx-file fx.py --seed-file seed.bin --buffer-size 134217728 --chunk-size 1048576 --delimiter-size 64 --padding-range 100 200 --decoy-ratio 0.01 --hash-name blake3 --verbosity info
 ```
-_Time: 4.313s_
+_Time: 3.321s_
 
 **Decoding:**
 ```bash
 vernamveil decode --infile /tmp/output.enc --outfile /tmp/output.dec --fx-file fx.py --seed-file seed.bin --buffer-size 136349200 --chunk-size 1048576 --delimiter-size 64 --padding-range 100 200 --decoy-ratio 0.01 --hash-name blake3 --verbosity info
 ```
-_Time: 4.183s_
+_Time: 3.352s_
 
 ### 🐇 AES-256-CBC (OpenSSL)
 
@@ -524,7 +524,7 @@ _Time: 2.636s_
 
 | Algorithm    | Encode Time | Decode Time |
 |--------------|-------------|-------------|
-| VernamVeil   | 4.313 s     | 4.183 s     |
+| VernamVeil   | 3.321 s     | 3.352 s     |
 | AES-256-CBC  | 3.007 s     | 2.636 s     |
 
 ---

--- a/tests/test_deniability_utils.py
+++ b/tests/test_deniability_utils.py
@@ -52,7 +52,7 @@ class TestDeniabilityUtils(unittest.TestCase):
             auth_encrypt=False,
         )
         decoy_out, _ = fake_cypher.decode(cyphertext, fake_seed)
-        return decoy_out.decode(), decoy_message.decode()
+        return decoy_out, decoy_message
 
     def _combo_name(self, chunk_size, delimiter_size, padding_range, decoy_ratio):
         """Produce a string name for the test combo."""

--- a/tests/test_vernamveil.py
+++ b/tests/test_vernamveil.py
@@ -58,9 +58,10 @@ class TestVernamVeil(unittest.TestCase):
         )
 
         def test(cypher, _):
-            encrypted, _ = cypher.encode(message.encode(), self.initial_seed)
+            msg = message.encode()
+            encrypted, _ = cypher.encode(msg, self.initial_seed)
             decrypted, _ = cypher.decode(encrypted, self.initial_seed)
-            self.assertEqual(message, decrypted.decode())
+            self.assertEqual(msg, decrypted)
 
         # Test with all combinations of siv_seed_initialisation and auth_encrypt
         self._for_all_modes(test, siv_seed_initialisation=True, auth_encrypt=True)
@@ -78,10 +79,10 @@ class TestVernamVeil(unittest.TestCase):
 
         def test(cypher, _):
             for i in range(150):
-                msg = "".join(random.choices(string.printable, k=i))
-                encrypted, _ = cypher.encode(msg.encode(), self.initial_seed)
+                msg = ("".join(random.choices(string.printable, k=i))).encode()
+                encrypted, _ = cypher.encode(msg, self.initial_seed)
                 decrypted, _ = cypher.decode(encrypted, self.initial_seed)
-                self.assertEqual(msg, decrypted.decode(), f"Failed at length {i}")
+                self.assertEqual(msg, decrypted, f"Failed at length {i}")
 
         # Test with all combinations of siv_seed_initialisation and auth_encrypt
         self._for_all_modes(test, siv_seed_initialisation=True, auth_encrypt=True)

--- a/vernamveil/_cypher.py
+++ b/vernamveil/_cypher.py
@@ -52,7 +52,7 @@ class _Cypher(ABC):
     @abstractmethod
     def encode(
         self, message: bytes | bytearray | memoryview, seed: bytes
-    ) -> tuple[bytearray, bytes]:
+    ) -> tuple[memoryview, bytes]:
         """Encrypt a message.
 
         Args:
@@ -60,7 +60,7 @@ class _Cypher(ABC):
             seed (bytes): Initial seed for encryption.
 
         Returns:
-            tuple[bytearray, bytes]: Encrypted message and final seed.
+            tuple[memoryview, bytes]: Encrypted message and final seed.
 
         Raises:
             ValueError: If the delimiter appears in the message.
@@ -70,7 +70,7 @@ class _Cypher(ABC):
     @abstractmethod
     def decode(
         self, cyphertext: bytes | bytearray | memoryview, seed: bytes
-    ) -> tuple[bytearray, bytes]:
+    ) -> tuple[memoryview, bytes]:
         """Decrypt an encoded message.
 
         Args:
@@ -78,7 +78,7 @@ class _Cypher(ABC):
             seed (bytes): Initial seed for decryption.
 
         Returns:
-            tuple[bytearray, bytes]: Decrypted message and final seed.
+            tuple[memoryview, bytes]: Decrypted message and final seed.
 
         Raises:
             ValueError: If the authentication tag does not match.

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -361,16 +361,16 @@ class VernamVeil(_Cypher):
 
         return memoryview(noisy_blocks)
 
-    def _deobfuscate(self, noisy: bytearray, seed: bytes, delimiter: memoryview) -> bytearray:
+    def _deobfuscate(self, noisy: memoryview, seed: bytes, delimiter: memoryview) -> memoryview:
         """Remove noise and extract real chunks from a shuffled noisy message.
 
         Args:
-            noisy (bytearray): Decrypted and obfuscated message.
+            noisy (memoryview): Decrypted and obfuscated message.
             seed (bytes): Seed for deterministic chunk deshuffling.
             delimiter (memoryview): Delimiter used to detect chunks.
 
         Returns:
-            bytearray: Original message reconstructed from real chunks.
+            memoryview: Original message reconstructed from real chunks.
         """
         # Estimate the ranges of all chunks
         delimiter_len = len(delimiter)
@@ -408,20 +408,19 @@ class VernamVeil(_Cypher):
 
         # Reconstruct and unshuffle the message
         message = bytearray(exact_size)
-        view = memoryview(noisy)
         current_loc = 0
         for pos in shuffled_positions:
             start, end = all_chunk_ranges[pos]
 
             next_loc = current_loc + end - start
-            message[current_loc:next_loc] = view[start:end]
+            message[current_loc:next_loc] = noisy[start:end]
             current_loc = next_loc
 
-        return message
+        return memoryview(message)
 
     def _xor_with_key(
         self, data: memoryview, seed: bytes, is_encode: bool
-    ) -> tuple[bytearray, bytes]:
+    ) -> tuple[memoryview, bytes]:
         """Encrypt or decrypt data using XOR with the generated keystream.
 
         Args:
@@ -430,7 +429,7 @@ class VernamVeil(_Cypher):
             is_encode (bool): True for encryption, False for decryption.
 
         Returns:
-            tuple[bytearray, bytes]: Processed data and the final seed.
+            tuple[memoryview, bytes]: Processed data and the final seed.
         """
         # Preallocate memory and avoid copying when slicing
         data_len = len(data)
@@ -463,7 +462,7 @@ class VernamVeil(_Cypher):
             # Refresh the seed differently for encoding and decoding
             seed = self._hash(seed, [plaintext_data])
 
-        return result, seed
+        return memoryview(result), seed
 
     def _generate_delimiter(self, seed: bytes) -> tuple[memoryview, bytes]:
         """Create a delimiter sequence using the key stream and update the seed.
@@ -480,7 +479,7 @@ class VernamVeil(_Cypher):
 
     def encode(
         self, message: bytes | bytearray | memoryview, seed: bytes
-    ) -> tuple[bytearray, bytes]:
+    ) -> tuple[memoryview, bytes]:
         """Encrypt a message.
 
         Args:
@@ -488,7 +487,7 @@ class VernamVeil(_Cypher):
             seed (bytes): Initial seed for encryption.
 
         Returns:
-            tuple[bytearray, bytes]: Encrypted message and final seed.
+            tuple[memoryview, bytes]: Encrypted message and final seed.
 
         Raises:
             ValueError: If the delimiter appears in the message.
@@ -498,7 +497,7 @@ class VernamVeil(_Cypher):
             message = memoryview(message)
 
         # Store the output parts
-        output: list[bytes | bytearray] = []
+        output: list[memoryview] = []
 
         # SIV seed initialisation: Encrypt and prepend a synthetic IV (SIV) derived from the seed and message.
         # This prevents deterministic keystreams on the first block and makes the scheme resilient to seed reuse.
@@ -508,7 +507,7 @@ class VernamVeil(_Cypher):
             siv_hash = self._hash(seed, [timestamp, message])
             # Encrypt the synthetic IV and evolve the seed with it
             encrypted_siv_hash, seed = self._xor_with_key(memoryview(siv_hash), seed, True)
-            # Use the encrypted SIV hash bytearray as the output; this puts it in front
+            # Put the encrypted SIV hash in front
             output.append(encrypted_siv_hash)
 
             # Note: The SIV is not reused for MAC computation, ensuring separation
@@ -541,7 +540,7 @@ class VernamVeil(_Cypher):
         if self._auth_encrypt:
             # The tag is computed over the configuration of the cypher and the cyphertext.
             tag = self._hash(auth_seed, [str(self).encode(), cyphertext], use_hmac=True)
-            output.append(tag)
+            output.append(memoryview(tag))
 
         # Concatenate all parts into a single bytearray
         result = bytearray(sum(len(part) for part in output))
@@ -551,11 +550,11 @@ class VernamVeil(_Cypher):
             result[current_loc:next_loc] = part
             current_loc = next_loc
 
-        return result, last_seed
+        return memoryview(result), last_seed
 
     def decode(
         self, cyphertext: bytes | bytearray | memoryview, seed: bytes
-    ) -> tuple[bytearray, bytes]:
+    ) -> tuple[memoryview, bytes]:
         """Decrypt an encoded message.
 
         Args:
@@ -563,7 +562,7 @@ class VernamVeil(_Cypher):
             seed (bytes): Initial seed for decryption.
 
         Returns:
-            tuple[bytearray, bytes]: Decrypted message and final seed.
+            tuple[memoryview, bytes]: Decrypted message and final seed.
 
         Raises:
             ValueError: If the authentication tag does not match.

--- a/vernamveil/_vernamveil.py
+++ b/vernamveil/_vernamveil.py
@@ -148,13 +148,15 @@ class VernamVeil(_Cypher):
     def _allocate_array(
         self, num_bytes: int
     ) -> "bytearray | np.ndarray[tuple[int], np.dtype[np.uint8]]":
-        """Allocate an empty byte array or numpy array for the given number of bytes.
+        """Allocate an empty bytearray or numpy array for the given number of bytes.
+
+        This method checks if the FX is vectorised and allocates the appropriate type.
 
         Args:
             num_bytes (int): The number of bytes to allocate.
 
         Returns:
-            bytearray or np.ndarray: An empty byte array or numpy array of uint8 type.
+            bytearray or np.ndarray: An empty bytearray or numpy array of uint8 type.
         """
         if self._fx.vectorise:
             return np.empty(num_bytes, dtype=np.uint8)


### PR DESCRIPTION
Fixes https://github.com/datumbox/VernamVeil/issues/41

After implementing https://github.com/datumbox/VernamVeil/pull/42, I realised I could potentially get the same effect without removing the Scalar API. We could just have the type of the buffer depend on the vectorisation flag of the FX:
- In non-vectorised mode, bytearrays will be used.
- In vectorised mode, numpy arrays will be used.

The benchmarks show we can get the same speed without losing the scalar API.

Previous baseline from #40:
```
The 'encode' step took 4.313 seconds.
The 'decode' step took 4.183 seconds.
```

Using https://github.com/datumbox/VernamVeil/pull/42 (782fa1d) and removing the scalar API:
```
The 'encode' step took 3.307 seconds.
The 'decode' step took 3.356 seconds.
```

Maintaining the scalar API but just adopting conditional buffers (39cb8b8):
```
The 'encode' step took 3.321 seconds.
The 'decode' step took 3.352 seconds.
```

Pretty much the same!

Though simplifying the code and removing the scalar API is not off the table, from Memory management perspective, we can decouple these decision. We will merge this PR instead of #42 as we literally incur no penalty by keeping the scalar API and revise it on the future.